### PR TITLE
Davidl

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -34,8 +34,8 @@ installdir = "#%s" %(osname)
 include    = "%s/include" % (installdir)
 bin        = "%s/bin" % (installdir)
 lib        = "%s/lib" % (installdir)
-env = Environment(CXX         = os.getenv('CXX', 'g++'),
-                  CC          = os.getenv('CC' , 'gcc'),
+env = Environment(CXX         = os.getenv('CXX', 'c++'),
+                  CC          = os.getenv('CC' , 'cc'),
                   FC          = os.getenv('FC' , 'gfortran'),
                   CPPPATH     = ['.'])
 


### PR DESCRIPTION
use generic names for compilers c++ instead of g++ and cc instead of gcc
