### PR TITLE
* BarrelEMcal_HDDS.xml [rtj]

### DIFF
--- a/BarrelEMcal_HDDS.xml
+++ b/BarrelEMcal_HDDS.xml
@@ -86,7 +86,6 @@ caused conflict with drift chamber cable supports.
   </composition>
 
   <composition name="barrelModule" envelope="BCAM">
-    <apply region="nullBfield"/>
     <posXYZ volume="BCL0" />
     <posXYZ volume="BCALlayer_1" />
     <posXYZ volume="BCALlayer_2" />
@@ -319,7 +318,9 @@ caused conflict with drift chamber cable supports.
                                       comment="barrel EMcal mother" />
   <tubs name="BCAM" Rio_Z="64.2485 90.5185 425.0" profile="-3.75 7.5"
                     unit_length="cm" unit_angle="deg"
-                    material="Air" comment="barrel calorimeter module" />
+                    material="Air" comment="barrel calorimeter module">
+    <apply region="nullBfield"/>
+  </tubs>
   <tubs name="BCAS" Rio_Z="87.3435 90.5185 390.0" profile="-3.75 7.5"
                     unit_length="cm" unit_angle="deg"
                     material="Aluminum" comment="bcal module support bar" />


### PR DESCRIPTION
- Change the way that the null magnetic field is applied in the BCAL
   to make it more like the way it is applied in the FCAL and elsewhere
   in the geometry. The old way, the BCAM module itself had the solenoid
   field inside, but all of its dozens of daughters had their interior
   fields individually nulled. After this change the mother BCAM module
   has a null field, and all of the daughters inherit it from her.  This
   makes the description more compact in Geant4 and is more consistent
   with the way that fields are handled in other parts of the geometry.
