### PR TITLE
Survey update

### DIFF
--- a/CentralDC_HDDS.xml
+++ b/CentralDC_HDDS.xml
@@ -292,6 +292,10 @@
 
   <pcon name="CDC" material="Air" comment="CDC mother volume">
     <polyplane Rio_Z="8.75 60.5663 -81.45"/>
+    <polyplane Rio_Z="8.75 60.5663 -69.0"/>
+    <polyplane Rio_Z="9.18 60.5663 -69.0"/>
+    <polyplane Rio_Z="9.18 60.5663 75.5"/>
+    <polyplane Rio_Z="8.75 60.5663 75.5"/>
     <polyplane Rio_Z="8.75 60.5663 78.91"/>
     <polyplane Rio_Z="8.75 57.9374 78.91"/>
     <polyplane Rio_Z="8.75 57.9374 81.45"/>

--- a/CentralDC_HDDS.xml
+++ b/CentralDC_HDDS.xml
@@ -67,7 +67,7 @@
 
   <composition name="CentralDC">
     <posXYZ volume="centralDC" X_Y_Z="0.0  0.0  71.71" />
-    <posXYZ volume="CDCB" X_Y_Z="0.0 0.0 -9.74" />    <!-- upstream cables  -->
+    <posXYZ volume="CDCB" X_Y_Z="0.0 0.0 -9.75" />    <!-- upstream cables  -->
   </composition>
 
   <composition name="centralDC" envelope="CDC">

--- a/CentralDC_HDDS.xml
+++ b/CentralDC_HDDS.xml
@@ -86,8 +86,8 @@
     <posXYZ volume="CDIU" X_Y_Z="0.0 0.0 -70.46"/> <!-- upstream inner collar -->
     <posXYZ volume="CDID" X_Y_Z="0.0 0.0 77.04"/>  <!-- downstream inner collar -->
     <posXYZ volume="CDGD" X_Y_Z="0.0 0.0 +80.16"/> <!-- downstream rhoacell outer ring -->
-    <posXYZ volume="CDGI" X_Y_Z="0.0 0.0 +79.653"/> <!-- downstream rhoacell inner ring #1 --> 
-    <posXYZ volume="CDG2" X_Y_Z="0.0 0.0 +80.923"/> <!-- downstream rhoacell inner ring #2 -->
+    <posXYZ volume="CDGI" X_Y_Z="0.0 0.0 +80.16"/> <!-- downstream rhoacell inner ring #1 --> 
+    <!--posXYZ volume="CDG2" X_Y_Z="0.0 0.0 +79.399"/> <downstream rhoacell inner ring #2, moved to DCLS volume -->
     <posXYZ volume="CDGW" X_Y_Z="0.0 0.0 +81.436"/> <!-- downstream mylar gas window -->
     <posXYZ volume="CDGU" X_Y_Z="0.0 0.0 -76.63125"/> <!-- upstream plexiglass gas plate -->
     <posXYZ volume="CDGS" X_Y_Z="0.0 0.0 -74.25"/> <!-- upstream gas plenum shell -->  
@@ -98,6 +98,7 @@
  </composition>
 
   <composition name="CDClayers" envelope="DCLS">
+    <posXYZ volume="CDG2" X_Y_Z="0.0 0.0 +76.108"/> <!-- downstream rhoacell inner ring #2 -->
     <posXYZ volume="CDPD" X_Y_Z="0.0 0.0 +75.300" 
                           geometry_layer="1"/>     <!-- downstream end plate -->
     <posXYZ volume="CDPU" X_Y_Z="0.0 0.0 -75.47625"
@@ -320,9 +321,9 @@
 	                           comment="CDC upstream gas plenum inner shell" />
   <tubs name="CDGD" Rio_Z="55.5374  57.9374    2.54" material="MediumDensityROHACELL"
 	                           comment="CDC downstream gas plenum ring" />
-  <tubs name="CDGI" Rio_Z="8.8392  10.033  1.524" material="MediumDensityROHACELL"
+  <tubs name="CDGI" Rio_Z="8.8392  10.033  2.54" material="MediumDensityROHACELL"
 	                           comment="first part of CDC downstream gas plenum inner ring" /> 
-  <tubs name="CDG2" Rio_Z="8.8392  11.1252  1.016" material="MediumDensityROHACELL"
+  <tubs name="CDG2" Rio_Z="10.04  11.1252  1.016" material="MediumDensityROHACELL"
 	                           comment="second part of CDC downstream gas plenum inner ring" />
   <tubs name="CDGW" Rio_Z="8.8392   57.9374    0.01" material="AluminizedMylar"
 	                           comment="CDC downstream gas plenum window" />

--- a/CentralDC_HDDS.xml
+++ b/CentralDC_HDDS.xml
@@ -289,8 +289,15 @@
   <!-- Sat Sep 27 15:00:14 EDT 2008 B.Z. -->
   <!-- CDC volume 5cm shorter and fill it with Ar/CO2 gas-->
 
-  <tubs name="CDC" Rio_Z="8.75   60.5663   162.9" material="Air"
-	                           comment="CDC mother volume"/>
+  <pcon name="CDC" material="Air" comment="CDC mother volume">
+    <polyplane Rio_Z="8.75 60.5663 -81.45"/>
+    <polyplane Rio_Z="8.75 60.5663 78.91"/>
+    <polyplane Rio_Z="8.75 57.9374 78.91"/>
+    <polyplane Rio_Z="8.75 57.9374 81.45"/>
+  </pcon>
+
+  <!--tubs name="CDC" Rio_Z="8.75   60.5663   162.9" material="Air"
+	                           comment="CDC mother volume"/-->
   <tubs name="CDCI" Rio_Z="9.1821  9.2329 150.0" material="E-fiberGlass"
 	                           comment="CDC inner cylinder"/>
   <tubs name="CDOC" Rio_Z="57.6326  57.8612 2.5" material="E-fiberGlass"

--- a/ForwardDC_HDDS.xml
+++ b/ForwardDC_HDDS.xml
@@ -64,8 +64,8 @@
     <mposPhi volume="FMT3" ncopy="2" R_Z="61.53 -97.9512"/>
 
     <!-- Rails -->
-    <posXYZ volume="FRA2" X_Y_Z="-63.8285 -1.45074 0. "/>
-    <posXYZ volume="FRA2" X_Y_Z="+63.8285 -1.45074 0. "/>
+    <posXYZ volume="FRA2" X_Y_Z="-63.6285 -1.6207 0. "/>
+    <posXYZ volume="FRA2" X_Y_Z="+63.6285 -1.6207 0. "/>
     <posXYZ volume="FRA1" X_Y_Z="-63.1535 0. 0. "/>
     <posXYZ volume="FRA1" X_Y_Z="+63.1535 0. 0. "/>
 
@@ -845,7 +845,7 @@
 
 
 
-  <tubs name="FDC" Rio_Z="0.0 64.2485 198.0" material="Air"
+  <tubs name="FDC" Rio_Z="0.0 64.0485 198.0" material="Air"
                                  comment="forward drift chambers" />
   <tubs name="FDP1" Rio_Z="0.0 59.0 14.2724" material="Air"
                                  comment="forward drift chamber package 1" />

--- a/ForwardDC_HDDS.xml
+++ b/ForwardDC_HDDS.xml
@@ -217,17 +217,17 @@
 <!--Downstream gusset ring ledge-->  
     <posXYZ volume="FDGU" X_Y_Z="0.0 0.0 +76.5928"/>
  
-    <posXYZ volume="forwardDC_package_1" X_Y_Z="-0.09  0.033  -87.648 " rot="0.0493 -0.01633 0.0882">
+    <posXYZ volume="forwardDC_package_1" X_Y_Z="-0.09  0.033  -87.648 " rot="0.0493 0.01633 0.0882">
 
       <identifier field="package" value="1" />
     </posXYZ>
-    <posXYZ volume="forwardDC_package_2" X_Y_Z="-0.069  0.06  -29.078 " rot="0.0352 -0.02263 0.0080">
+    <posXYZ volume="forwardDC_package_2" X_Y_Z="-0.069  0.06  -29.078 " rot="0.0352 0.02263 0.0089">
       <identifier field="package" value="2" />
     </posXYZ>
-    <posXYZ volume="forwardDC_package_3" X_Y_Z="0.001  -0.033  +29.511 " rot="0.0682 -0.02922 0.0295">
+    <posXYZ volume="forwardDC_package_3" X_Y_Z="0.001  -0.033  +29.511 " rot="0.0682 0.02922 0.0295">
       <identifier field="package" value="3" />
     </posXYZ>
-    <posXYZ volume="forwardDC_package_4" X_Y_Z="0.018  0.023  +68.186 "  rot="-0.1097 0.00172 0.0066" >
+    <posXYZ volume="forwardDC_package_4" X_Y_Z="0.018  0.023  +68.186 "  rot="-0.1097 -0.00172 0.0066" >
       <identifier field="package" value="4" />
     </posXYZ>  
 

--- a/ForwardDC_HDDS.xml
+++ b/ForwardDC_HDDS.xml
@@ -72,265 +72,266 @@
 
    <!-- Fixtures for attachment to rail system -->
    <!--- Package 1 beam left -->
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -95.618" rot="0 0 60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -94.98285"/>
-    <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 -87.6486"/>  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -80.31435"/> 
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -79.6792" rot="0 0 60.0" /> 
-    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -93.8591" />
-    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -81.4541" />
-    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -79.99675" />   
-    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -95.30045" />
-    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -93.8591" />
-    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -81.4541" />
-    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 -93.8591"/>
-    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 -81.4541"/>  
-    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -93.8591"/>
-    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -81.4541"/>
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -95.718" rot="0 0 60.0" />  
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -95.08285"/>
+    <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 -87.7486"/>  
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -80.41435"/> 
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -79.5792" rot="0 0 60.0" /> 
+    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -93.9591" />
+    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -81.5541" />
+    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -80.09675" />   
+    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -95.40045" />
+    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -93.9591" />
+    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -81.5541" />
+    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 -93.9591"/>
+    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 -81.5541"/>  
+    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -93.9591"/>
+    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -81.5541"/>
    <!--- Package 1 beam right -->
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -95.618" rot="0 0 -60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -94.98285"/>
-    <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 -87.6486"/>  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -80.31435"/> 
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -79.6792" rot="0 0 -60.0" />
-    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -93.8591" />
-    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -81.4541" />
-    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -79.99675" />   
-    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -95.30045" />
-    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -93.8591" />
-    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -81.4541" />
-    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 -93.8591"/>
-    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 -81.4541"/>  
-    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -93.8591"/>
-    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -81.4541"/>
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -95.718" rot="0 0 -60.0" />  
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -95.08285"/>
+    <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 -87.7486"/>  
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -80.41435"/> 
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -79.5792" rot="0 0 -60.0" />
+    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -93.9591" />
+    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -81.5541" />
+    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -80.09675" />   
+    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -95.40045" />
+    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -93.9591" />
+    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -81.5541" />
+    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 -93.9591"/>
+    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 -81.5541"/>  
+    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -93.9591"/>
+    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -81.5541"/>
    <!-- Nuts for package 1 -->
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -96.0268" Phi0="0.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -79.269"  Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -96.1268" Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -79.169"  Phi0="0.0"/>
    <!--- Package 2 beam left -->
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -37.1856" rot="0 0 60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -36.55045"/>
-    <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 -29.2162"/>  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -21.88195"/> 
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -21.2468" rot="0 0 60.0" />
-    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -35.4267" />
-    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -23.0217" />
-    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -21.56435" />   
-    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -36.86805" />
-    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -35.4267" />
-    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -23.0217" />
-    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 -35.4267"/>
-    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 -23.0217"/>  
-    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -35.4267"/>
-    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -23.0217"/>
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -37.0476" rot="0 0 60.0" />  
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -36.41245"/>
+    <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 -29.0782"/>  
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -21.64395"/> 
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -21.0088" rot="0 0 60.0" />
+    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -35.2887" />
+    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -22.7837" />
+    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -21.32635" />   
+    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -36.73005" />
+    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -35.2887" />
+    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -22.7837" />
+    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 -35.2887"/>
+    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 -22.7837"/>  
+    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -35.2887"/>
+    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -22.7837"/>
    <!--- Package 2 beam right -->
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -37.1856" rot="0 0 -60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -36.55045"/>
-    <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 -29.2162"/>  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -21.88195"/> 
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -21.2468" rot="0 0 -60.0" />
-    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -35.4267" />
-    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -23.0217" />
-    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -21.56435" />   
-    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -36.86805" />
-    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -35.4267" />
-    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -23.0217" />
-    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 -35.4267"/>
-    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 -23.0217"/>  
-    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -35.4267"/>
-    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -23.0217"/>
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -37.0476" rot="0 0 -60.0" />  
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -36.41245"/>
+    <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 -29.0782"/>  
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -21.64395"/> 
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -21.0088" rot="0 0 -60.0" />
+    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -35.2887" />
+    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -22.7837" />
+    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -21.32635" />   
+    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -36.73005" />
+    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -35.2887" />
+    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -22.7837" />
+    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 -35.2887"/>
+    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 -22.7837"/>  
+    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -35.2887"/>
+    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -22.7837"/>
    <!-- Nuts for package 2 -->
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -37.5944" Phi0="0.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -20.8380"  Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -37.4564" Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -20.6000"  Phi0="0.0"/>
    <!--- Package 3 beam left -->
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 37.1856" rot="0 0 60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 36.55045"/>
-    <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 29.2162"/>  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 21.88195"/> 
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 21.2468" rot="0 0 60.0" />
-    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 35.4267" />
-    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 23.0217" />
-    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 21.56435" />   
-    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 36.86805" />
-    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 35.4267" />
-    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 23.0217" />
-    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 35.4267"/>
-    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 23.0217"/>  
-    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 35.4267"/>
-    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 23.0217"/>
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 37.5856" rot="0 0 60.0" />  
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 36.95045"/>
+    <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 29.6162"/>  
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 22.18195"/> 
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 21.5468" rot="0 0 60.0" />
+    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 35.8267" />
+    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 23.3217" />
+    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 21.86435" />   
+    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 37.26805" />
+    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 35.8267" />
+    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 23.3217" />
+    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 35.8267"/>
+    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 23.3217"/>  
+    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 35.8267"/>
+    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 23.3217"/>
    <!--- Package 3 beam right -->
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 37.1856" rot="0 0 -60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 36.55045"/>
-    <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 29.2162"/>  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 21.88195"/> 
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 21.2468" rot="0 0 -60.0" />
-    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 35.4267" />
-    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 23.0217" />
-    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 21.56435" />   
-    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 36.86805" />
-    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 35.4267" />
-    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 23.0217" />
-    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 35.4267"/>
-    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 23.0217"/>  
-    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 35.4267"/>
-    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 23.0217"/>
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 37.5856" rot="0 0 -60.0" />  
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 36.95045"/>
+    <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 29.6162"/>  
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 22.18195"/> 
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 21.5468" rot="0 0 -60.0" />
+    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 35.8267" />
+    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 23.3217" />
+    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 21.86435" />   
+    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 37.26805" />
+    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 35.8267" />
+    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 23.3217" />
+    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 35.8267"/>
+    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 23.3217"/>  
+    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 35.8267"/>
+    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 23.3217"/>
   <!-- Nuts for package 3 -->
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 37.5944" Phi0="0.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 20.8380"  Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 37.9944" Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 21.1380"  Phi0="0.0"/>
   <!--- Package 4 beam left -->
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 75.618" rot="0 0 60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549  74.98285"/>
-    <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 67.6486"/>  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 60.31435"/> 
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 59.6792" rot="0 0 60.0" />
-    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 73.8591" />
-    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 61.4541" />
-    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 59.99675" />   
-    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 75.30045" />
-    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 73.8591" />
-    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 61.4541" />
-    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 73.8591"/>
-    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 61.4541"/>  
-    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 73.8591"/>
-    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 61.4541"/>
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 76.256" rot="0 0 60.0" />  
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549  75.62085"/>
+    <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 68.2866"/>  
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 60.85235"/> 
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 60.2172" rot="0 0 60.0" />
+    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 74.4971" />
+    <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 61.9921" />
+    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 60.53475" />   
+    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 75.93845" />
+    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 74.4971" />
+    <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 61.9921" />
+    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 74.4971"/>
+    <posXYZ volume="FBA7" X_Y_Z="62.78925 -0.61875 61.9921"/>  
+    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 74.4971"/>
+    <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 61.9921"/>
    <!--- Package 4 beam right -->
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 75.618" rot="0 0 -60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 74.98285"/>
-    <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 67.6486"/>  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 60.31435"/> 
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 59.6792" rot="0 0 -60.0" />
-    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 73.8591" />
-    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 61.4541" />
-    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 59.99675" />   
-    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 75.30045" />
-    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 73.8591" />
-    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 61.4541" />
-    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 73.8591"/>
-    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 61.4541"/>  
-    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 73.8591"/>
-    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 61.4541"/>  
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 76.256" rot="0 0 -60.0" />  
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 75.62085"/>
+    <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 68.2866"/>  
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 60.85235"/> 
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 60.2172" rot="0 0 -60.0" />
+    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 74.4971" />
+    <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 61.9921" />
+    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 60.53475" />   
+    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 75.93845" />
+    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 74.4971" />
+    <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 61.9921" />
+    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 74.4971"/>
+    <posXYZ volume="FBA7" X_Y_Z="-62.78925 -0.61875 61.9921"/>  
+    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 74.4971"/>
+    <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 61.9921"/>  
    <!-- Nuts for package 4 -->
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 76.0268" Phi0="0.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 59.2690"  Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 76.6648" Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 59.8070"  Phi0="0.0"/>
 
 <!--Upstream gusset ring ledge-->
-    <posXYZ volume="FDGU" X_Y_Z="0.0 0.0 -95.9548"/>   
+    <posXYZ volume="FDGU" X_Y_Z="0.0 0.0 -96.0548"/>   
 <!--Downstream gusset ring ledge-->  
-    <posXYZ volume="FDGU" X_Y_Z="0.0 0.0 +75.9548"/>
+    <posXYZ volume="FDGU" X_Y_Z="0.0 0.0 +76.5928"/>
  
-    <posXYZ volume="forwardDC_package_1" X_Y_Z="0.0  0.0  -87.6486">
+    <posXYZ volume="forwardDC_package_1" X_Y_Z="-0.09  0.033  -87.648 " rot="0.0493 -0.01633 0.0882">
+
       <identifier field="package" value="1" />
     </posXYZ>
-    <posXYZ volume="forwardDC_package_2" X_Y_Z="0.0  0.0  -29.2162">
+    <posXYZ volume="forwardDC_package_2" X_Y_Z="-0.069  0.06  -29.078 " rot="0.0352 -0.02263 0.0080">
       <identifier field="package" value="2" />
     </posXYZ>
-    <posXYZ volume="forwardDC_package_3" X_Y_Z="0.0  0.0  +29.2162">
+    <posXYZ volume="forwardDC_package_3" X_Y_Z="0.001  -0.033  +29.511 " rot="0.0682 -0.02922 0.0295">
       <identifier field="package" value="3" />
     </posXYZ>
-    <posXYZ volume="forwardDC_package_4" X_Y_Z="0.0  0.0  +67.6486">
+    <posXYZ volume="forwardDC_package_4" X_Y_Z="0.018  0.023  +68.186 "  rot="-0.1097 0.00172 0.0066" >
       <identifier field="package" value="4" />
     </posXYZ>  
 
 <!--Interpackage support rods -->
-    <mposPhi volume="FDRL" ncopy="3" R_Z="52.25 -58.4324" Phi0="30.0"/>
-    <mposPhi volume="FDRL" ncopy="3" R_Z="52.25 0.0" Phi0="30.0"/> 
-    <mposPhi volume="FDZL" ncopy="3" R_Z="52.25 48.4324" Phi0="30.0"/>
+    <mposPhi volume="FDRL" ncopy="3" R_Z="52.25 -58.363 " Phi0="30.0"/>
+    <mposPhi volume="FDRL" ncopy="3" R_Z="52.25 0.2165" Phi0="30.0"/> 
+    <mposPhi volume="FDZL" ncopy="3" R_Z="52.25 48.8485" Phi0="30.0"/>
 <!-- Package compression nuts -->
     <!-- Package 1 -->
-    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 -95.0348" Phi0="15.0"/> 
-    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 -95.0348" Phi0="90.0"/>
+    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 -95.1348" Phi0="15.0"/> 
+    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 -95.1348" Phi0="90.0"/>
     <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 -95.3916" Phi0="0.0"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -95.5348"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 -95.5348"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -79.7624"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 -79.7624"/> 
-    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 -95.0348"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 -95.0348"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 -80.2624"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 -80.2624"/>
-    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 -80.2624" Phi0="15.0"/> 
-    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 -80.2624" Phi0="90.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 -79.9056" Phi0="0.0"/>
-    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 -96.0268"/>
-    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 -79.269"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 -96.0268"/>
-    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 -79.269"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -95.6348"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 -95.6348"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -79.6624"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 -79.6624"/> 
+    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 -95.1348"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 -95.1348"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 -80.1624"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 -80.1624"/>
+    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 -80.1624" Phi0="15.0"/> 
+    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 -80.1624" Phi0="90.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 -79.8056" Phi0="0.0"/>
+    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 -96.1268"/>
+    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 -79.169"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 -96.1268"/>
+    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 -79.169"/>
     <!-- Package 2 -->
-    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 -36.6024" Phi0="15.0"/> 
-    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 -36.6024" Phi0="90.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 -36.95925" Phi0="0.0"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -37.1024"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 -37.1024"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -21.33"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 -21.33"/> 
-    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 -36.6024"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 -36.6024"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 -21.83"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 -21.83"/>
-    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 -21.83" Phi0="15.0"/> 
-    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 -21.83" Phi0="90.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 -21.4731" Phi0="0.0"/>
-    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 -37.5944"/>
-    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 -20.8380"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 -37.5944"/>
-    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 -20.8380"/>
+    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 -36.4644" Phi0="15.0"/> 
+    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 -36.4644" Phi0="90.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 -36.82125" Phi0="0.0"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -36.9644"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 -36.9644"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -21.092"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 -21.092"/> 
+    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 -36.4644"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 -36.4644"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 -21.592"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 -21.592"/>
+    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 -21.592" Phi0="15.0"/> 
+    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 -21.592" Phi0="90.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 -21.2351" Phi0="0.0"/>
+    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 -37.4564"/>
+    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 -20.0600"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 -37.4564"/>
+    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 -20.0600"/>
     <!-- Package 3 -->
-    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 36.6024" Phi0="15.0"/> 
-    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 36.6024" Phi0="90.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 36.95925" Phi0="0.0"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 37.1024"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 37.1024"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 21.33"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 21.33"/> 
-    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 36.6024"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 36.6024"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 21.83"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 21.83"/>
-    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 21.83" Phi0="15.0"/> 
-    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 21.83" Phi0="90.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 21.4731" Phi0="0.0"/>
-    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 37.5944"/>
-    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 20.8380"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 37.5944"/>
-    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 20.8380"/>
+    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 37.0024" Phi0="15.0"/> 
+    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 37.0024" Phi0="90.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 37.35925" Phi0="0.0"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 37.5024"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 37.5024"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 21.63"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 21.63"/> 
+    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 37.0024"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 37.0024"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 22.13"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 22.13"/>
+    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 22.13" Phi0="15.0"/> 
+    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 22.13" Phi0="90.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 21.7731" Phi0="0.0"/>
+    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 37.9944"/>
+    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 21.1380"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 37.9944"/>
+    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 21.1380"/>
     <!-- Package 4 -->
-    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 75.0348" Phi0="15.0"/> 
-    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 75.0348" Phi0="90.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 75.3916" Phi0="0.0"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 75.5348"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 75.5348"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 59.7624"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 59.7624"/> 
-    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 75.0348"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 75.0348"/>
-    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 60.2624"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 60.2624"/>
-    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 60.2624" Phi0="15.0"/> 
-    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 60.2624" Phi0="90.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 59.90555" Phi0="0.0"/>
-    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 76.0268"/>
-    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 59.269"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 76.0268"/>
-    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 59.269"/>
+    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 75.6728" Phi0="15.0"/> 
+    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 75.6728" Phi0="90.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 76.0296" Phi0="0.0"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 76.1728"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 76.1728"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 60.3004"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 60.3004"/> 
+    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 76.3108"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 76.3108"/>
+    <posXYZ volume="FDXN" X_Y_Z="26.125 45.2498 60.8004"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-26.125 45.2498 60.8004"/>
+    <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 60.8004" Phi0="15.0"/> 
+    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 60.8004" Phi0="90.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 60.44355" Phi0="0.0"/>
+    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 76.6648"/>
+    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 59.807"/> 
+    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 76.6648"/>
+    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 59.807"/>
 
 <!-- Interpackage spacers -->   
-    <mposZ volume="forwardDC_inter_package" ncopy="2" Z0="-58.4324" dZ="58.4324" />
-    <posXYZ volume="forwardDC_inter_package_last" X_Y_Z="0. 0. 48.4324" />
+    <mposZ volume="forwardDC_inter_package" ncopy="2" Z0="-58.3634" dZ="58.5394" />
+    <posXYZ volume="forwardDC_inter_package_last" X_Y_Z="0. 0. 48.8485" />
 
 <!-- Cable support shells and brackets -->
-   <mposZ volume="FDS1" ncopy="2" Z0="-58.4324" dZ="58.4234" />
-   <mposZ volume="FDS2" ncopy="1" Z0="48.4324" dZ="58.4234" />
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 -78.289  "/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 -38.575"/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 -19.8575"/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 19.8575"/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 38.575"/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 58.289"/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -80.1949  "/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -36.67"/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -21.7625"/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 21.7625"/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 36.67"/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 60.1949"/>
+   <mposZ volume="FDS1" ncopy="2" Z0="-58.3634" dZ="58.4234" />
+   <mposZ volume="FDS2" ncopy="1" Z0="48.8485" dZ="58.4234" />
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 -78.189  "/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 -38.437"/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 -19.6195"/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 20.1575"/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 38.975"/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 58.827"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -80.0949  "/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -36.532"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -21.5245"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 22.0625"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 37.07"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 60.62"/>
 
 <!-- Cables -->
     <posXYZ volume="FDE8" X_Y_Z="0.0 0.0 -12.2076" rot="0.0 0.0 245.50"/>
@@ -362,89 +363,89 @@
     <posXYZ volume="FDE1" X_Y_Z="0.0 0.0 -89.8804" rot="0.0 0.0 122.5"/> 
 
 <!-- Tygon tubes for fluorinert -->
-    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="-34.02 -50.64 0.0"/> 
-    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="-34.02 -50.64 -58.4324"/> 
-    <posXYZ volume="forwardDC_short_tygon_tube" X_Y_Z="-34.02 -50.64 48.4324"/>
-    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="+34.02 -50.64 0.0"/> 
-    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="+34.02 -50.64 -58.4324"/> 
-    <posXYZ volume="forwardDC_short_tygon_tube" X_Y_Z="+34.02 -50.64 48.4324"/>
-    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="-26.94 -54.75 0.0"/> 
-    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="-26.94 -54.75 -58.4324"/> 
-    <posXYZ volume="forwardDC_short_tygon_tube" X_Y_Z="-26.94 -54.75 48.4324"/>
-    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="+26.94 -54.75 0.0"/> 
-    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="+26.94 -54.75 -58.4324"/> 
-    <posXYZ volume="forwardDC_short_tygon_tube" X_Y_Z="+26.94 -54.75 48.4324"/>
+    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="-34.02 -50.64 0.2165"/> 
+    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="-34.02 -50.64 -58.3634"/> 
+    <posXYZ volume="forwardDC_short_tygon_tube" X_Y_Z="-34.02 -50.64 48.8485"/>
+    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="+34.02 -50.64 0.2165"/> 
+    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="+34.02 -50.64 -58.3634"/> 
+    <posXYZ volume="forwardDC_short_tygon_tube" X_Y_Z="+34.02 -50.64 48.8485"/>
+    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="-26.94 -54.75 0.2165"/> 
+    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="-26.94 -54.75 -58.3634"/> 
+    <posXYZ volume="forwardDC_short_tygon_tube" X_Y_Z="-26.94 -54.75 48.8485"/>
+    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="+26.94 -54.75 0.2165"/> 
+    <posXYZ volume="forwardDC_long_tygon_tube" X_Y_Z="+26.94 -54.75 -58.3634"/> 
+    <posXYZ volume="forwardDC_short_tygon_tube" X_Y_Z="+26.94 -54.75 48.8485"/>
 
 
     <!-- Cooling manifolds and loops -->
     <!-- Package 1 -->
     <posXYZ volume="forwardDC_upstream_manifold" X_Y_Z="-30.41568 -52.58143 -87.6486" rot="0.0 180.0 240.0" />
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -95.0348" rot="0.0 180 60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -80.2624" rot="0.0 180 60.0"/>
-    <mposZ volume="FDCB" ncopy ="6" Z0= "-93.7094" dZ="2.1254" /> 
-    <mposZ volume="FDCB" ncopy ="6" Z0= "-93.2154" dZ="2.1254" /> 
-    <mposZ volume="FDCB" ncopy ="6" Z0= "-92.2069" dZ="2.1254" /> 
-    <mposZ volume="FCB1" ncopy ="6" Z0= "-93.7094" dZ="2.1254" /> 
-    <mposZ volume="FCB1" ncopy ="6" Z0= "-93.2154" dZ="2.1254" /> 
-    <mposZ volume="FCB1" ncopy ="6" Z0= "-92.2069" dZ="2.1254" /> 
-    <mposZ volume="forwardDC_cooling_loop" ncopy="6" Z0= "-92.9621" dZ="2.1254" />
-  <mposZ volume="forwardDC_cooling_loop2" ncopy="6" Z0= "-92.9621" dZ="2.1254" />
-    <mposZ volume="FDCM" ncopy="6" Z0="-92.7831" dZ="2.1254" />
-    <mposZ volume="FCM1" ncopy="6" Z0="-92.7831" dZ="2.1254" />
-    <posXYZ volume="forwardDC_upstream_manifold" X_Y_Z="30.41568 -52.58143 -87.6486" rot="0.0 180.0 -60.0" />
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -95.0348" rot="0.0 180 -60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -80.2624" rot="0.0 180 -60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -95.1348" rot="0.0 180 60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -80.1624" rot="0.0 180 60.0"/>
+    <mposZ volume="FDCB" ncopy ="6" Z0= "-93.8094" dZ="2.1254" /> 
+    <mposZ volume="FDCB" ncopy ="6" Z0= "-93.3154" dZ="2.1254" /> 
+    <mposZ volume="FDCB" ncopy ="6" Z0= "-92.3069" dZ="2.1254" /> 
+    <mposZ volume="FCB1" ncopy ="6" Z0= "-93.8094" dZ="2.1254" /> 
+    <mposZ volume="FCB1" ncopy ="6" Z0= "-93.3154" dZ="2.1254" /> 
+    <mposZ volume="FCB1" ncopy ="6" Z0= "-92.3069" dZ="2.1254" /> 
+    <mposZ volume="forwardDC_cooling_loop" ncopy="6" Z0= "-93.0621" dZ="2.1254" />
+  <mposZ volume="forwardDC_cooling_loop2" ncopy="6" Z0= "-93.0621" dZ="2.1254" />
+    <mposZ volume="FDCM" ncopy="6" Z0="-92.8831" dZ="2.1254" />
+    <mposZ volume="FCM1" ncopy="6" Z0="-92.8831" dZ="2.1254" />
+    <posXYZ volume="forwardDC_upstream_manifold" X_Y_Z="30.41568 -52.58143 -87.7486" rot="0.0 180.0 -60.0" />
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -95.1348" rot="0.0 180 -60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -80.1624" rot="0.0 180 -60.0"/>
     <!-- Package 2 -->
-    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 -29.2162" rot="0.0 0.0 60.0" />
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -36.6024" rot="0.0 180 60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -21.830" rot="0.0 180 60.0"/>
-    <mposZ volume="FDCB" ncopy ="6" Z0= "-35.277" dZ="2.1254" /> 
-    <mposZ volume="FDCB" ncopy ="6" Z0= "-34.783" dZ="2.1254" /> 
-    <mposZ volume="FDCB" ncopy ="6" Z0= "-33.7745" dZ="2.1254" />   
-    <mposZ volume="FCB1" ncopy ="6" Z0= "-35.277" dZ="2.1254" /> 
-    <mposZ volume="FCB1" ncopy ="6" Z0= "-34.783" dZ="2.1254" /> 
-    <mposZ volume="FCB1" ncopy ="6" Z0= "-33.7745" dZ="2.1254" /> 
-    <mposZ volume="forwardDC_cooling_loop" ncopy="6" Z0= "-34.5297" dZ="2.1254" />
-    <mposZ volume="forwardDC_cooling_loop2" ncopy="6" Z0= "-34.5297" dZ="2.1254" />
-    <mposZ volume="FDCM" ncopy="6" Z0="-34.3507" dZ="2.1254" /> 
-    <mposZ volume="FCM1" ncopy="6" Z0="-34.3507" dZ="2.1254" />
-    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="30.41568 -52.58143 -29.2162" rot="0.0 180.0 -60.0" />
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -36.6024" rot="0.0 180 -60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -21.83" rot="0.0 180 -60.0"/>
+    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 -28.9782" rot="0.0 0.0 60.0" />
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -36.4644" rot="0.0 180 60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -21.592" rot="0.0 180 60.0"/>
+    <mposZ volume="FDCB" ncopy ="6" Z0= "-35.139" dZ="2.1254" /> 
+    <mposZ volume="FDCB" ncopy ="6" Z0= "-34.645" dZ="2.1254" /> 
+    <mposZ volume="FDCB" ncopy ="6" Z0= "-33.6365" dZ="2.1254" />   
+    <mposZ volume="FCB1" ncopy ="6" Z0= "-35.139" dZ="2.1254" /> 
+    <mposZ volume="FCB1" ncopy ="6" Z0= "-34.645" dZ="2.1254" /> 
+    <mposZ volume="FCB1" ncopy ="6" Z0= "-33.6365" dZ="2.1254" /> 
+    <mposZ volume="forwardDC_cooling_loop" ncopy="6" Z0= "-34.3917" dZ="2.1254" />
+    <mposZ volume="forwardDC_cooling_loop2" ncopy="6" Z0= "-34.3917" dZ="2.1254" />
+    <mposZ volume="FDCM" ncopy="6" Z0="-34.2127" dZ="2.1254" /> 
+    <mposZ volume="FCM1" ncopy="6" Z0="-34.2127" dZ="2.1254" />
+    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="30.41568 -52.58143 -29.0782" rot="0.0 180.0 -60.0" />
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -36.4644" rot="0.0 180 -60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -21.592" rot="0.0 180 -60.0"/>
     <!-- Package 3 -->
-    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 29.2162" rot="0.0 0.0 60.0" />
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 36.6024" rot="0.0 180 60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 21.830" rot="0.0 180 60.0"/>
-    <mposZ volume="FDCB" ncopy ="6" Z0= "23.1554" dZ="2.1254" /> 
-    <mposZ volume="FDCB" ncopy ="6" Z0= "23.6494" dZ="2.1254" /> 
-    <mposZ volume="FDCB" ncopy ="6" Z0= "24.6579" dZ="2.1254" />  
-    <mposZ volume="FCB1" ncopy ="6" Z0= "23.1554" dZ="2.1254" /> 
-    <mposZ volume="FCB1" ncopy ="6" Z0= "23.6494" dZ="2.1254" /> 
-    <mposZ volume="FCB1" ncopy ="6" Z0= "24.6579" dZ="2.1254" /> 
-    <mposZ volume="forwardDC_cooling_loop" ncopy="6" Z0= "23.9027" dZ="2.1254" />  
-    <mposZ volume="forwardDC_cooling_loop2" ncopy="6" Z0= "23.9027" dZ="2.1254" />
-    <mposZ volume="FDCM" ncopy="6" Z0="24.0817" dZ="2.1254" />
-    <mposZ volume="FCM1" ncopy="6" Z0="24.0817" dZ="2.1254" />
-    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="30.41568 -52.58143 29.2162" rot="0.0 180.0 -60.0" />
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 36.6024" rot="0.0 180 -60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 21.83" rot="0.0 180 -60.0"/>
+    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 29.52162" rot="0.0 0.0 60.0" />
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 37.0024" rot="0.0 180 60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 22.130" rot="0.0 180 60.0"/>
+    <mposZ volume="FDCB" ncopy ="6" Z0= "23.4554" dZ="2.1254" /> 
+    <mposZ volume="FDCB" ncopy ="6" Z0= "23.9494" dZ="2.1254" /> 
+    <mposZ volume="FDCB" ncopy ="6" Z0= "24.9579" dZ="2.1254" />  
+    <mposZ volume="FCB1" ncopy ="6" Z0= "23.4554" dZ="2.1254" /> 
+    <mposZ volume="FCB1" ncopy ="6" Z0= "23.9494" dZ="2.1254" /> 
+    <mposZ volume="FCB1" ncopy ="6" Z0= "24.9579" dZ="2.1254" /> 
+    <mposZ volume="forwardDC_cooling_loop" ncopy="6" Z0= "24.2027" dZ="2.1254" />  
+    <mposZ volume="forwardDC_cooling_loop2" ncopy="6" Z0= "24.2027" dZ="2.1254" />
+    <mposZ volume="FDCM" ncopy="6" Z0="24.3817" dZ="2.1254" />
+    <mposZ volume="FCM1" ncopy="6" Z0="24.3817" dZ="2.1254" />
+    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="30.41568 -52.58143 29.5162" rot="0.0 180.0 -60.0" />
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 37.0024" rot="0.0 180 -60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 22.13" rot="0.0 180 -60.0"/>
     <!-- Package 4 -->
-    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 67.6486" rot="0.0 0.0 60.0" />
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 60.2624" rot="0.0 180 60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 75.0348" rot="0.0 180 60.0"/>
-    <mposZ volume="FDCB" ncopy ="6" Z0= "61.5878" dZ="2.1254" /> 
-    <mposZ volume="FDCB" ncopy ="6" Z0= "62.0818" dZ="2.1254" /> 
-    <mposZ volume="FDCB" ncopy ="6" Z0= "63.0903" dZ="2.1254" />  
-    <mposZ volume="FCB1" ncopy ="6" Z0= "61.5878" dZ="2.1254" /> 
-    <mposZ volume="FCB1" ncopy ="6" Z0= "62.0818" dZ="2.1254" /> 
-    <mposZ volume="FCB1" ncopy ="6" Z0= "63.0903" dZ="2.1254" /> 
-    <mposZ volume="forwardDC_cooling_loop" ncopy="6" Z0= "62.3351" dZ="2.1254" /> 
-    <mposZ volume="forwardDC_cooling_loop2" ncopy="6" Z0= "62.3351" dZ="2.1254" />
-    <mposZ volume="FDCM" ncopy="6" Z0="62.5141" dZ="2.1254" />
-    <mposZ volume="FCM1" ncopy="6" Z0="62.5141" dZ="2.1254" />
-    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="30.41568 -52.58143 67.6486" rot="0.0 180.0 -60.0" />
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 60.2624" rot="0.0 180 -60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 75.0348" rot="0.0 180 -60.0"/>
+    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 68.2866" rot="0.0 0.0 60.0" />
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 60.8004" rot="0.0 180 60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 75.6728" rot="0.0 180 60.0"/>
+    <mposZ volume="FDCB" ncopy ="6" Z0= "62.1258" dZ="2.1254" /> 
+    <mposZ volume="FDCB" ncopy ="6" Z0= "62.6198" dZ="2.1254" /> 
+    <mposZ volume="FDCB" ncopy ="6" Z0= "63.6283" dZ="2.1254" />  
+    <mposZ volume="FCB1" ncopy ="6" Z0= "62.2578" dZ="2.1254" /> 
+    <mposZ volume="FCB1" ncopy ="6" Z0= "62.6198" dZ="2.1254" /> 
+    <mposZ volume="FCB1" ncopy ="6" Z0= "63.6283" dZ="2.1254" /> 
+    <mposZ volume="forwardDC_cooling_loop" ncopy="6" Z0= "62.8731" dZ="2.1254" /> 
+    <mposZ volume="forwardDC_cooling_loop2" ncopy="6" Z0= "62.8731" dZ="2.1254" />
+    <mposZ volume="FDCM" ncopy="6" Z0="63.0521" dZ="2.1254" />
+    <mposZ volume="FCM1" ncopy="6" Z0="63.0521" dZ="2.1254" />
+    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="30.41568 -52.58143 68.1866" rot="0.0 180.0 -60.0" />
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 60.8004" rot="0.0 180 -60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 75.6728" rot="0.0 180 -60.0"/>
 
   </composition>
 

--- a/ForwardDC_HDDS.xml
+++ b/ForwardDC_HDDS.xml
@@ -75,11 +75,11 @@
     <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -95.718" rot="0 0 60.0" />  
     <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -95.08285"/>
     <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 -87.7486"/>  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -80.41435"/> 
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -80.31435"/> 
     <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -79.5792" rot="0 0 60.0" /> 
     <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -93.9591" />
     <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -81.5541" />
-    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -80.09675" />   
+    <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -79.99675" />   
     <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -95.40045" />
     <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -93.9591" />
     <posXYZ volume="FBA6" X_Y_Z="63.270 0.9857 -81.5541" />
@@ -91,11 +91,11 @@
     <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -95.718" rot="0 0 -60.0" />  
     <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -95.08285"/>
     <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 -87.7486"/>  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -80.41435"/> 
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -80.31435"/> 
     <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -79.5792" rot="0 0 -60.0" />
     <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -93.9591" />
     <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -81.5541" />
-    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -80.09675" />   
+    <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -79.99675" />   
     <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -95.40045" />
     <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -93.9591" />
     <posXYZ volume="FBA6" X_Y_Z="-63.270 0.9857 -81.5541" />
@@ -107,11 +107,11 @@
     <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -96.1268" Phi0="0.0"/>
     <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -79.169"  Phi0="0.0"/>
    <!--- Package 2 beam left -->
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -37.0476" rot="0 0 60.0" />  
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -37.05125" rot="0 0 60.0" />  
     <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -36.41245"/>
     <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 -29.0782"/>  
     <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 -21.64395"/> 
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -21.0088" rot="0 0 60.0" />
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 -20.9088" rot="0 0 60.0" />
     <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -35.2887" />
     <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 -22.7837" />
     <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 -21.32635" />   
@@ -123,11 +123,11 @@
     <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -35.2887"/>
     <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 -22.7837"/>
    <!--- Package 2 beam right -->
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -37.0476" rot="0 0 -60.0" />  
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -37.05125" rot="0 0 -60.0" />  
     <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -36.41245"/>
     <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 -29.0782"/>  
     <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 -21.64395"/> 
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -21.0088" rot="0 0 -60.0" />
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 -20.9088" rot="0 0 -60.0" />
     <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -35.2887" />
     <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 -22.7837" />
     <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 -21.32635" />   
@@ -139,14 +139,14 @@
     <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -35.2887"/>
     <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 -22.7837"/>
    <!-- Nuts for package 2 -->
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -37.4564" Phi0="0.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -20.6000"  Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -37.4661" Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 -20.5000"  Phi0="0.0"/>
    <!--- Package 3 beam left -->
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 37.5856" rot="0 0 60.0" />  
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 37.6856" rot="0 0 60.0" />  
     <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 36.95045"/>
     <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 29.6162"/>  
     <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 22.18195"/> 
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 21.5468" rot="0 0 60.0" />
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 21.4468" rot="0 0 60.0" />
     <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 35.8267" />
     <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 23.3217" />
     <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 21.86435" />   
@@ -158,11 +158,11 @@
     <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 35.8267"/>
     <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 23.3217"/>
    <!--- Package 3 beam right -->
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 37.5856" rot="0 0 -60.0" />  
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 37.6856" rot="0 0 -60.0" />  
     <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 36.95045"/>
     <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 29.6162"/>  
     <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 22.18195"/> 
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 21.5468" rot="0 0 -60.0" />
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 21.4468" rot="0 0 -60.0" />
     <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 35.8267" />
     <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 23.3217" />
     <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 21.86435" />   
@@ -174,14 +174,14 @@
     <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 35.8267"/>
     <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 23.3217"/>
   <!-- Nuts for package 3 -->
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 37.9944" Phi0="0.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 21.1380"  Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 38.0944" Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 21.0380"  Phi0="0.0"/>
   <!--- Package 4 beam left -->
     <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 76.256" rot="0 0 60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549  75.62085"/>
+    <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549  75.6208 "/>
     <posXYZ volume="FBA3" X_Y_Z="61.2386 0.3549 68.2866"/>  
     <posXYZ volume="FBA1" X_Y_Z="56.351 0.3549 60.85235"/> 
-    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 60.2172" rot="0 0 60.0" />
+    <posXYZ volume="FBA2" X_Y_Z="55.0 -6.5 60.1172" rot="0 0 60.0" />
     <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 74.4971" />
     <posXYZ volume="FBA4" X_Y_Z="62.0245 0.3549 61.9921" />
     <posXYZ volume="FBA5" X_Y_Z="59.6845 0.3549 60.53475" />   
@@ -194,10 +194,10 @@
     <posXYZ volume="FBA7" X_Y_Z="63.75075 0.37945 61.9921"/>
    <!--- Package 4 beam right -->
     <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 76.256" rot="0 0 -60.0" />  
-    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 75.62085"/>
+    <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 75.6208 "/>
     <posXYZ volume="FBA3" X_Y_Z="-61.2386 0.3549 68.2866"/>  
     <posXYZ volume="FBA1" X_Y_Z="-56.351 0.3549 60.85235"/> 
-    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 60.2172" rot="0 0 -60.0" />
+    <posXYZ volume="FBA2" X_Y_Z="-55.0 -6.5 60.1172" rot="0 0 -60.0" />
     <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 74.4971" />
     <posXYZ volume="FBA4" X_Y_Z="-62.0245 0.3549 61.9921" />
     <posXYZ volume="FBA5" X_Y_Z="-59.6845 0.3549 60.53475" />   
@@ -210,7 +210,7 @@
     <posXYZ volume="FBA7" X_Y_Z="-63.75075 0.37945 61.9921"/>  
    <!-- Nuts for package 4 -->
     <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 76.6648" Phi0="0.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 59.8070"  Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="58.8 59.7070"  Phi0="0.0"/>
 
 <!--Upstream gusset ring ledge-->
     <posXYZ volume="FDGU" X_Y_Z="0.0 0.0 -96.0548"/>   
@@ -232,14 +232,14 @@
     </posXYZ>  
 
 <!--Interpackage support rods -->
-    <mposPhi volume="FDRL" ncopy="3" R_Z="52.25 -58.363 " Phi0="30.0"/>
+    <mposPhi volume="FDRL" ncopy="3" R_Z="52.25 -58.356 " Phi0="30.0"/>
     <mposPhi volume="FDRL" ncopy="3" R_Z="52.25 0.2165" Phi0="30.0"/> 
     <mposPhi volume="FDZL" ncopy="3" R_Z="52.25 48.8485" Phi0="30.0"/>
 <!-- Package compression nuts -->
     <!-- Package 1 -->
     <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 -95.1348" Phi0="15.0"/> 
     <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 -95.1348" Phi0="90.0"/>
-    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 -95.3916" Phi0="0.0"/>
+    <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 -95.4916" Phi0="0.0"/>
     <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -95.6348"/> 
     <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 -95.6348"/>
     <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 -79.6624"/> 
@@ -289,13 +289,13 @@
     <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 22.13" Phi0="15.0"/> 
     <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 22.13" Phi0="90.0"/>
     <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 21.7731" Phi0="0.0"/>
-    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 37.9944"/>
+    <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 38.0944"/>
     <posXYZ volume="FDXN" X_Y_Z="50.44 -13.48 21.1380"/> 
-    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 37.9944"/>
+    <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 38.0944"/>
     <posXYZ volume="FDXN" X_Y_Z="-50.44 -13.48 21.1380"/>
     <!-- Package 4 -->
     <mposPhi volume="FDXN" ncopy="12" R_Z="52.25 75.6728" Phi0="15.0"/> 
-    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 75.6728" Phi0="90.0"/>
+    <mposPhi volume="FDXN" ncopy="6" R_Z="52.25 75.6748" Phi0="90.0"/>
     <mposPhi volume="FDXN" ncopy="2" R_Z="52.25 76.0296" Phi0="0.0"/>
     <posXYZ volume="FDXN" X_Y_Z="26.125 -45.2498 76.1728"/> 
     <posXYZ volume="FDXN" X_Y_Z="-26.125 -45.2498 76.1728"/>
@@ -318,20 +318,20 @@
     <posXYZ volume="forwardDC_inter_package_last" X_Y_Z="0. 0. 48.8485" />
 
 <!-- Cable support shells and brackets -->
-   <mposZ volume="FDS1" ncopy="2" Z0="-58.3634" dZ="58.4234" />
+   <mposZ volume="FDS1" ncopy="2" Z0="-58.3634" dZ="58.6234" />
    <mposZ volume="FDS2" ncopy="1" Z0="48.8485" dZ="58.4234" />
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 -78.189  "/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 -38.437"/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 -19.6195"/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 20.1575"/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 38.975"/>
-   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2 58.827"/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2  -78.089  "/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2  -38.537"/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2  -19.5195"/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2  20.0575"/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2  39.075"/>
+   <mposPhi volume="FAB2" ncopy="24" Phi0="7.5" R_Z="58.2  58.7129"/>
    <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -80.0949  "/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -36.532"/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -21.5245"/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 22.0625"/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 37.07"/>
-   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 60.62"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -36.575"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 -21.4245"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 21.9625"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 37.17"/>
+   <mposPhi volume="FAB1" ncopy="24" Phi0="7.5" R_Z="56.6 60.6179"/>
 
 <!-- Cables -->
     <posXYZ volume="FDE8" X_Y_Z="0.0 0.0 -12.2076" rot="0.0 0.0 245.50"/>
@@ -396,8 +396,8 @@
     <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -95.1348" rot="0.0 180 -60.0"/>
     <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -80.1624" rot="0.0 180 -60.0"/>
     <!-- Package 2 -->
-    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 -28.9782" rot="0.0 0.0 60.0" />
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -36.4644" rot="0.0 180 60.0"/>
+    <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 -28.9997" rot="0.0 0.0 60.0" />
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -36.5644" rot="0.0 180 60.0"/>
     <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 -21.592" rot="0.0 180 60.0"/>
     <mposZ volume="FDCB" ncopy ="6" Z0= "-35.139" dZ="2.1254" /> 
     <mposZ volume="FDCB" ncopy ="6" Z0= "-34.645" dZ="2.1254" /> 
@@ -410,12 +410,12 @@
     <mposZ volume="FDCM" ncopy="6" Z0="-34.2127" dZ="2.1254" /> 
     <mposZ volume="FCM1" ncopy="6" Z0="-34.2127" dZ="2.1254" />
     <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="30.41568 -52.58143 -29.0782" rot="0.0 180.0 -60.0" />
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -36.4644" rot="0.0 180 -60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -36.5644" rot="0.0 180 -60.0"/>
     <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 -21.592" rot="0.0 180 -60.0"/>
     <!-- Package 3 -->
     <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 29.52162" rot="0.0 0.0 60.0" />
     <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 37.0024" rot="0.0 180 60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 22.130" rot="0.0 180 60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 22.030" rot="0.0 180 60.0"/>
     <mposZ volume="FDCB" ncopy ="6" Z0= "23.4554" dZ="2.1254" /> 
     <mposZ volume="FDCB" ncopy ="6" Z0= "23.9494" dZ="2.1254" /> 
     <mposZ volume="FDCB" ncopy ="6" Z0= "24.9579" dZ="2.1254" />  
@@ -428,7 +428,7 @@
     <mposZ volume="FCM1" ncopy="6" Z0="24.3817" dZ="2.1254" />
     <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="30.41568 -52.58143 29.5162" rot="0.0 180.0 -60.0" />
     <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 37.0024" rot="0.0 180 -60.0"/>
-    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 22.13" rot="0.0 180 -60.0"/>
+    <posXYZ volume="FCBS" X_Y_Z="27.655 -47.8 22.03" rot="0.0 180 -60.0"/>
     <!-- Package 4 -->
     <posXYZ volume="forwardDC_cooling_manifold" X_Y_Z="-30.41568 -52.58143 68.2866" rot="0.0 0.0 60.0" />
     <posXYZ volume="FCBS" X_Y_Z="-27.655 -47.8 60.8004" rot="0.0 180 60.0"/>
@@ -928,20 +928,20 @@
                                    comment="fdc anode wire circuit boards" />
   <tubs name="FDCP" Rio_Z=" 54.7 59.0 0.0270" material="CircuitBoards"
                                    comment="fdc readout preamp boards" />
-<tubs name="FDCB" Rio_Z="59.0 60.0 0.027" material="CircuitBoards"
+<tubs name="FDCB" Rio_Z="59.1 60.0 0.027" material="CircuitBoards"
                  profile="-54.5 289.0" 
                  comment="fdc readout preamp board extension" />
-<tubs name="FCB1" Rio_Z="59.0 60.0 0.027" material="CircuitBoards"
+<tubs name="FCB1" Rio_Z="59.1 60.0 0.027" material="CircuitBoards"
                  profile="-114.5 49.0" 
                  comment="fdc readout preamp board extension" />
   <tubs name="FDBC" Rio_Z=" 49.80 50.80 0.124" material="HVcapacitorSolder"
                                    comment="fdc blocking capacitors" />
   <tubs name="FDFP" Rio_Z=" 48.50 59.0 2.1254" material="Air"
                                    comment="fdc frame periodic container" />
-  <tubs name="FDRL" Rio_Z="0.7838 0.8890 43.16" material="FR-4"
+  <tubs name="FDRL" Rio_Z="0.7838 0.8890 43.1" material="FR-4"
                                    comment="fdc long support rods" />
 
-  <tubs name="FDZL" Rio_Z="0.7838 0.8890 23.16" material="FR-4"
+  <tubs name="FDZL" Rio_Z="0.7838 0.8890 23.1" material="FR-4"
                                    comment="fdc short support rods 4 last package" />
 
   <tubs name="FDRS" Rio_Z="0.0 0.240 13.8724" material="Aluminum"
@@ -987,9 +987,9 @@
                  comment="Gusset ring ledge" />  
   <tubs name="FDXN" Rio_Z="0.0 0.7938 0.50" material="Aluminum"
                  comment="O-ring compression nut" />
-  <tubs name="FDIS" Rio_Z="51.05 51.35 44.16" material="Air"
+  <tubs name="FDIS" Rio_Z="51.05 51.35 44.1" material="Air"
                  comment="Inter-package spacer mother volume"/>
-  <tubs name="FDIX" Rio_Z="51.05 51.35 24.16" material="Air"
+  <tubs name="FDIX" Rio_Z="51.05 51.35 24.1" material="Air"
                  comment="Inter-package spacer mother volume 4 last package"/>
   <tubs name="FDCL" Rio_Z="59.9 60.25 0.358" material="Copper" 
                  profile="-54.5 289.0" comment="Cooling loop"/> 

--- a/ForwardDC_HDDS.xml
+++ b/ForwardDC_HDDS.xml
@@ -844,10 +844,15 @@
    </composition>
 
 
+  <pcon name="FDC" material="Air" comment="forward drift chambers">
+    <polyplane Rio_Z= "58.05 64.0485 -99.0"/>
+    <polyplane Rio_Z= "58.05 64.0485 -97.5"/>
+    <polyplane Rio_Z= "0.0 64.0485 -97.5"/>
+    <polyplane Rio_Z= "0.0 64.0485 99.0"/>
+  </pcon>
 
-
-  <tubs name="FDC" Rio_Z="0.0 64.0485 198.0" material="Air"
-                                 comment="forward drift chambers" />
+  <!--tubs name="FDC" Rio_Z="0.0 64.0485 190.0" material="Air"
+                                 comment="forward drift chambers" /-->
   <tubs name="FDP1" Rio_Z="0.0 59.0 14.2724" material="Air"
                                  comment="forward drift chamber package 1" />
   <tubs name="FDP2" Rio_Z="0.0 59.0 14.2724" material="Air"
@@ -1086,9 +1091,9 @@
   <tubs name="FDS2" Rio_Z="58.66 58.74 21.0" material="FR-4"
        comment="Inter-package support skin for cables, package 4" />
 
-  <box name="FRA1" X_Y_Z="0.75 0.75 198.0" material="StainlessSteel"
+  <box name="FRA1" X_Y_Z="0.75 0.75 190.0" material="StainlessSteel"
        comment="FDC support rail part 1"/>
-  <box name="FRA2" X_Y_Z="0.6 2.49 198.0" material="StainlessSteel"
+  <box name="FRA2" X_Y_Z="0.6 2.49 190.0" material="StainlessSteel"
        comment="FDC support rail part 2"/>
 
   <box name="FBA1" X_Y_Z="10.0 2.2098 0.3175" material="Aluminum"

--- a/ForwardTOF_HDDS.xml
+++ b/ForwardTOF_HDDS.xml
@@ -36,69 +36,69 @@
 <!-- 2(long narrow paddles)(25) 19(long wide paddles)(44) 2(short paddles top/south) (46) -->
 
   <composition name="ForwardTOF">
-    <posXYZ volume="forwardTOF" X_Y_Z="0.0  0.0 1.27" rot="0 0 -90">
+    <posXYZ volume="forwardTOF" X_Y_Z="0.0  0.0 3.85" rot="0 0 -90">
       <plane value="0" />
     </posXYZ>
-    <posXYZ volume="forwardTOF" X_Y_Z="0.0  0.0 3.85" rot="0 0 0">
+    <posXYZ volume="forwardTOF" X_Y_Z="0.0  0.0 1.27" rot="0 0 0">
       <plane value="1" />
     </posXYZ>
   </composition>
 
   <composition name="forwardTOF" envelope="FTOF">
-    <posXYZ volume="forwardTOF_bottom1" X_Y_Z="0.0 -69.0 0.0" />
-    <posXYZ volume="forwardTOF_bottom2" X_Y_Z="0.0 -9.0 0.0" />
+    <posXYZ volume="forwardTOF_bottom1" X_Y_Z="0.0 -70.125 0.0" />
+    <posXYZ volume="forwardTOF_bottom2" X_Y_Z="0.0 -9.18 0.0" />
     <posXYZ volume="forwardTOF_north" X_Y_Z="+66.0 0.0 0.0" />
     <posXYZ volume="forwardTOF_south" X_Y_Z="-66.0 0.0 0.0" />
-    <posXYZ volume="forwardTOF_top2" X_Y_Z="0.0 +9.0 0.0" />
-    <posXYZ volume="forwardTOF_top1" X_Y_Z="0.0 +69.0 0.0" />
+    <posXYZ volume="forwardTOF_top2" X_Y_Z="0.0 +9.18 0.0" />
+    <posXYZ volume="forwardTOF_top1" X_Y_Z="0.0 +70.125 0.0" />
   </composition>
 
 <!-- the attribute 'row' is synonymous with 'bar' -->
   <composition name="forwardTOF_top1" envelope="FTOT">
-    <mposY volume="FTOC" ncopy="19" Z_X="0.0 0.0" Y0="-54.0" dY="6.00">
+    <mposY volume="FTOC" ncopy="19" Z_X="0.0 0.0" Y0="-54.855" dY="6.09">
       <row value="26" step="1" />
       <column value="0" />
     </mposY>
   </composition>
   <composition name="forwardTOF_top2" envelope="FTOY">
-    <mposY volume="FTOX" ncopy="2" Z_X="0.0 0.0" Y0="-1.5" dY="3.00">
+    <mposY volume="FTOX" ncopy="2" Z_X="0.0 0.0" Y0="-1.545" dY="3.09">
       <row value="24" step="1" />
       <column value="0" />
     </mposY>
   </composition>
   <composition name="forwardTOF_bottom1" envelope="FTOB">
-    <mposY volume="FTOC" ncopy="19" Z_X="0.0 0.0" Y0="-54.0" dY="6.00">
+    <mposY volume="FTOC" ncopy="19" Z_X="0.0 0.0" Y0="-54.855" dY="6.09">
       <row value="1" step="1" />
       <column value="0" />
     </mposY>
   </composition>
   <composition name="forwardTOF_bottom2" envelope="FTOZ">
-    <mposY volume="FTOX" ncopy="2" Z_X="0.0 0.0" Y0="-1.5" dY="3.00">
+    <mposY volume="FTOX" ncopy="2" Z_X="0.0 0.0" Y0="-1.545" dY="3.09">
       <row value="20" step="1" />
       <column value="0" />
     </mposY>
   </composition>
 
   <composition name="forwardTOF_north" envelope="FTON">
-    <mposY volume="FTOH" ncopy="2" Z_X = "0.0 0.0" Y0="-3.0" dY="6.0">
+    <mposY volume="FTOH" ncopy="2" Z_X = "0.0 0.0" Y0="-3.045" dY="6.09">
       <row value="22" step="1" />
       <column value="1" />
     </mposY>
   </composition>
   <composition name="forwardTOF_south" envelope="FTOS">
-    <mposY volume="FTOH" ncopy="2" Z_X="0.0 0.0" Y0="-3.0" dY="6.0">
+    <mposY volume="FTOH" ncopy="2" Z_X="0.0 0.0" Y0="-3.045" dY="6.09">
       <row value="45" step="1" />
       <column value="2" />
     </mposY>
   </composition>
 
-  <box name="FTOF" X_Y_Z="252.0 252.0 2.55" material="Air" />
-  <box name="FTOB" X_Y_Z="252.0 114.0 2.55" material="Air" />
-  <box name="FTOT" X_Y_Z="252.0 114.0 2.55" material="Air" />
-  <box name="FTOY" X_Y_Z="252.0   6.0 2.55" material="Air" />
-  <box name="FTOZ" X_Y_Z="252.0   6.0 2.55" material="Air" />
-  <box name="FTON" X_Y_Z="120.0  12.0 2.55" material="Air" />
-  <box name="FTOS" X_Y_Z="120.0  12.0 2.55" material="Air" />
+  <box name="FTOF" X_Y_Z="252.0 268.8 2.55" material="Air" />
+  <box name="FTOB" X_Y_Z="252.0 115.8 2.55" material="Air" />
+  <box name="FTOT" X_Y_Z="252.0 115.8 2.55" material="Air" />
+  <box name="FTOY" X_Y_Z="252.0   6.18 2.55" material="Air" />
+  <box name="FTOZ" X_Y_Z="252.0   6.18 2.55" material="Air" />
+  <box name="FTON" X_Y_Z="120.0  12.18 2.55" material="Air" />
+  <box name="FTOS" X_Y_Z="120.0  12.18 2.55" material="Air" />
   <box name="FTOC" X_Y_Z="252.0   6.0 2.54" material="Scintillator"
 					    sensitive="true" />
   <box name="FTOH" X_Y_Z="120.0   6.0 2.54" material="Scintillator"

--- a/Solenoid_HDDS.xml
+++ b/Solenoid_HDDS.xml
@@ -35,18 +35,7 @@
   </composition>
 
   <pcon name="LASS" material="Air">
-    <polyplane Rio_Z="50.0 188.0  -70.8" /> 
-    <polyplane Rio_Z="10.25 188.0   7.0"/>
-    <polyplane Rio_Z="7.9375 188.0  7.0" />
-    <polyplane Rio_Z="7.9375 188.0  10.0" />
-    <polyplane Rio_Z="7.62  188.0   10.0" />
-    <polyplane Rio_Z="7.62  188.0   29.345" />
-    <polyplane Rio_Z="6.35  188.0   29.345" />
-    <polyplane Rio_Z="6.35  188.0   40.024" />
-    <polyplane Rio_Z="4.7   188.0   42.724" />
-    <polyplane Rio_Z="4.7   188.0   81.025" />
-    <polyplane Rio_Z="2.5   188.0   83.244" />
-    <polyplane Rio_Z="0.0   188.0   83.244" />
+    <polyplane Rio_Z="0.0 188.0  -72.0" /> 
     <polyplane Rio_Z="0.0   188.0  460.0" />
   </pcon>
 

--- a/Solenoid_HDDS.xml
+++ b/Solenoid_HDDS.xml
@@ -35,8 +35,11 @@
   </composition>
 
   <pcon name="LASS" material="Air">
-    <polyplane Rio_Z="50.0 188.0  -70.8" />
-    <polyplane Rio_Z="7.62  188.0   0.0" />
+    <polyplane Rio_Z="50.0 188.0  -70.8" /> 
+    <polyplane Rio_Z="10.25 188.0   7.0"/>
+    <polyplane Rio_Z="7.9375 188.0  7.0" />
+    <polyplane Rio_Z="7.9375 188.0  10.0" />
+    <polyplane Rio_Z="7.62  188.0   10.0" />
     <polyplane Rio_Z="7.62  188.0   29.345" />
     <polyplane Rio_Z="6.35  188.0   29.345" />
     <polyplane Rio_Z="6.35  188.0   40.024" />

--- a/Solenoid_HDDS.xml
+++ b/Solenoid_HDDS.xml
@@ -36,10 +36,7 @@
 
   <pcon name="LASS" material="Air">
     <polyplane Rio_Z="50.0 188.0  -70.8" />
-    <polyplane Rio_Z="10.25 188.0   7.524"/>
-    <polyplane Rio_Z="7.9375 188.0  7.524" />
-    <polyplane Rio_Z="7.9375 188.0  10.06" />
-    <polyplane Rio_Z="7.62  188.0   10.06" />
+    <polyplane Rio_Z="7.62  188.0   0.0" />
     <polyplane Rio_Z="7.62  188.0   29.345" />
     <polyplane Rio_Z="6.35  188.0   29.345" />
     <polyplane Rio_Z="6.35  188.0   40.024" />

--- a/Solenoid_HDDS.xml
+++ b/Solenoid_HDDS.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--DOCTYPE HDDS>
-
   Hall D Geometry Data Base: Solenoid
   ************************************
-
      version 1.0: Initial version	-rtj
  
 <HDDS specification="v1.0" xmlns="http://www.gluex.org/hdds">
@@ -19,14 +17,21 @@
 <!-- Origin of Solenoid is center of the upstream edge of the first coil
     which also coincides with the inside surface of upstream mirror plate.  -->
 
+<!-- 2016/02/10 
+     a) The origin is set to the front surface of the upstream endplate
+        plus 20 inches. The front face can be easily surveyed, but not the inner face. 
+     b) The dimensions and positions of the yoke pieces are updated. The yoke cylinder
+        is simplified (as it was), incorporating the combined coils.   
+-->
+
   <composition name="Solenoid">
     <posXYZ volume="solenoid" X_Y_Z="0.0 0.0 0.0" />
   </composition>
 
   <composition name="solenoid">
     <posXYZ volume="IYUP" X_Y_Z="0.0 0.0 -25.4"> </posXYZ>
-    <posXYZ volume="IYOK" X_Y_Z="0.0 0.0 188.9"> </posXYZ>
-    <posXYZ volume="IYDN" X_Y_Z="0.0 0.0 410.8"> </posXYZ>
+    <posXYZ volume="IYOK" X_Y_Z="0.0 0.0 177.925"> </posXYZ>
+    <posXYZ volume="IYDN" X_Y_Z="0.0 0.0 392.26"> </posXYZ>
   </composition>
 
   <pcon name="LASS" material="Air">
@@ -35,19 +40,19 @@
     <polyplane Rio_Z="7.9375 188.0  7.524" />
     <polyplane Rio_Z="7.9375 188.0  10.06" />
     <polyplane Rio_Z="7.62  188.0   10.06" />
-    <polyplane Rio_Z="7.62  188.0   29.845" />
-    <polyplane Rio_Z="6.35  188.0   29.845" />
-    <polyplane Rio_Z="6.35  188.0   40.524" />
-    <polyplane Rio_Z="4.7   188.0   43.224" />
-    <polyplane Rio_Z="4.7   188.0   81.525" />
-    <polyplane Rio_Z="2.5   188.0   83.744" />
-    <polyplane Rio_Z="0.0   188.0   83.744" />
+    <polyplane Rio_Z="7.62  188.0   29.345" />
+    <polyplane Rio_Z="6.35  188.0   29.345" />
+    <polyplane Rio_Z="6.35  188.0   40.024" />
+    <polyplane Rio_Z="4.7   188.0   42.724" />
+    <polyplane Rio_Z="4.7   188.0   81.025" />
+    <polyplane Rio_Z="2.5   188.0   83.244" />
+    <polyplane Rio_Z="0.0   188.0   83.244" />
     <polyplane Rio_Z="0.0   188.0  460.0" />
   </pcon>
 
-  <tubs name="IYUP" Rio_Z=" 92.71 187.96  50.8" material="Iron" />
-  <tubs name="IYOK" Rio_Z=" 95.0 187.96  377.8" material="Iron" />
-  <tubs name="IYDN" Rio_Z=" 92.71 187.96  66.0" material="Iron" />
+  <tubs name="IYUP" Rio_Z=" 92.71 187.96   50.8"  material="Iron" />
+  <tubs name="IYOK" Rio_Z=" 95.0  187.96  355.85" material="Iron" />
+  <tubs name="IYDN" Rio_Z=" 92.71 187.96   72.82" material="Iron" />
 
   <!-- The following elements describe an early rendition of the GlueX
        detector simulated using a fast Monte Carlo program MCFast.  They

--- a/StartCntr_HDDS.xml
+++ b/StartCntr_HDDS.xml
@@ -31,8 +31,8 @@
      at the upstream limit of the sensitive region.        -->
 
   <composition name="StartCntr">  
-    <posXYZ volume="startCntrCables" X_Y_Z="0. 0. -17. "/>
-    <posXYZ volume="startCntr" X_Y_Z="0.03  0.123  0.0"  rot="-0.14122 0.09168 0.0"/>   
+    <posXYZ volume="startCntrCables" X_Y_Z="0. 0. -19. "/>
+    <posXYZ volume="startCntr" X_Y_Z="0.01  0.34  0.0"  rot="0.34274 0.0 0.0"/>   
     <!-- Plastic target at end of start counter -->
     <!--posXYZ volume="CAP2" X_Y_Z="0 0.0 58.89"/-->
   </composition>
@@ -61,13 +61,13 @@
     </mposPhi>
   </composition>
 
- <tubs name="STCM" Rio_Z="8.25 8.5 24.00" material="Air"
+ <tubs name="STCM" Rio_Z="8.25 8.5 20.00" material="Air"
                    comment="Start counter cables mother volume" />
 
  <tubs name="STCB" Rio_Z="7.0 7.9 5.864" material="Air"/> 
  <box name="STC1" X_Y_Z="0.1 3.81 5.364" material="CircuitBoards"/>
  <box name="STC2" X_Y_Z="0.5 3.5 1.0" material="FR-4"/>
- <box name="STCC" X_Y_Z="0.1 2.54 24.00" material="SignalCables"/>
+ <box name="STCC" X_Y_Z="0.1 2.54 20.00" material="SignalCables"/>
 
   <composition name="startCntr" envelope="STRT">
      <mposPhi volume="STRC" ncopy="30" Phi0="6.000000" R_Z="0.0  0.0"

--- a/Target_HDDS.xml
+++ b/Target_HDDS.xml
@@ -23,7 +23,7 @@
      liquid hydrogen target - not the start of the vacuum vessel.  -->
 
   <composition name="Target">
-    <posXYZ volume="targetSupportArm" X_Y_Z="0. 0. -86.645"/>
+    <posXYZ volume="targetSupportArm" X_Y_Z="0. 0. -70.461"/>
     <posXYZ volume="targetVessel" X_Y_Z="0. 0. 0.0" />
   </composition>
 
@@ -51,26 +51,26 @@
     <polyplane Rio_Z="0.0 7.9375 28.7368"/>
     <polyplane Rio_Z="0.0 7.9375 31.2768"/>
     <polyplane Rio_Z="0.0 7.62   31.2768"/>
-    <polyplane Rio_Z="0.0 7.62   49.82"/>
+    <polyplane Rio_Z="0.0 7.62   50.25"/>
  </pcon>
 
  <pcon name="TGBM" material="Aluminum">
-   <polyplane Rio_Z="6.0325 7.62 -36.825"/>
-   <polyplane Rio_Z="6.0325 7.62 -35.585"/>
-   <polyplane Rio_Z="6.0325 6.35 -35.585"/>
-   <polyplane Rio_Z="6.0325 6.35 -24.975"/>
-   <polyplane Rio_Z="3.699 4.118 -22.1565"/>
-   <polyplane Rio_Z="2.57 4.699 -22.1565"/>
-   <polyplane Rio_Z="2.25 4.699 -21.839"/>
+   <polyplane Rio_Z="6.0325 7.62 -20.2106"/>
+   <polyplane Rio_Z="6.0325 7.62 -18.9834"/>
+   <polyplane Rio_Z="6.0325 6.35 -18.9834"/>
+   <polyplane Rio_Z="6.0325 6.35 -8.3734"/>
+   <polyplane Rio_Z="3.699 4.118 -5.5549"/>
+   <polyplane Rio_Z="2.57 4.699 -5.5549"/>
+   <polyplane Rio_Z="2.25 4.699 -5.2374"/>
   </pcon>
 
   <composition name="targetVessel" envelope="TARG">
-    <posXYZ volume="CYLW" X_Y_Z="0. 0. 16.608" />
-    <posXYZ volume="TGBM" X_Y_Z="0. 0. 16.608"/>
+    <posXYZ volume="CYLW" X_Y_Z="0. 0. 0." />
+    <posXYZ volume="TGBM" X_Y_Z="0. 0. 0."/>
     <posXYZ volume="DWIT" X_Y_Z="0. 0. +34.8465"/>
     <posXYZ volume="TGR0" X_Y_Z="0. 0. -12.5015"/>
     <posXYZ volume="TGR0" X_Y_Z="0. 0. -15.359"/>
-    <posXYZ volume="targetInput" X_Y_Z="0. 0. 15.00"/>
+    <posXYZ volume="targetInput" X_Y_Z="0. 0. 15.00" rot="0.0076 0.004 0.0"/>
     <posXYZ volume="targetTube" X_Y_Z="0. 0. 15.00" rot="0.0076 0.004 0.0"/>
   </composition>
 
@@ -104,14 +104,14 @@
   </pcon>
 
   <pcon name="CYLW" material="HighDensityROHACELL" comment="target vessel cylindrical wall">
-    <polyplane Rio_Z="3.699 4.699 -21.839"/>
-    <polyplane Rio_Z="3.699 4.699 +13.2435"/>
-    <polyplane Rio_Z="3.665 4.672 +14.2435"/>
-    <polyplane Rio_Z="3.381 4.453 +15.2435"/>
-    <polyplane Rio_Z="2.726 3.979 +16.2435"/>
-    <polyplane Rio_Z="1.905 3.135 +17.2435"/>
-    <polyplane Rio_Z="1.905 2.466 +17.7435"/>
-    <polyplane Rio_Z="1.905 1.905 +18.2514"/>
+    <polyplane Rio_Z="3.699 4.699 -5.2374"/>
+    <polyplane Rio_Z="3.699 4.699 29.8451"/>
+    <polyplane Rio_Z="3.665 4.672 30.8451"/>
+    <polyplane Rio_Z="3.381 4.453 31.8451"/>
+    <polyplane Rio_Z="2.726 3.979 32.8451"/>
+    <polyplane Rio_Z="1.905 3.135 33.8451"/>
+    <polyplane Rio_Z="1.905 2.466 34.3451"/>
+    <polyplane Rio_Z="1.905 1.905 34.853"/>
   </pcon>
 
 
@@ -162,7 +162,7 @@
   </pcon>
     
   <pcon name="TARG" material="Vacuum" comment="target vessel mother volume">
-    <polyplane Rio_Z="0. 7.62  -22.2234"/>
+    <polyplane Rio_Z="0. 7.62  -20.2106"/>
     <polyplane Rio_Z="0. 7.62  -18.9834"/>
     <polyplane Rio_Z="0. 6.35  -18.9834"/>
     <polyplane Rio_Z="0. 6.35   -8.3734"/>

--- a/Target_HDDS.xml
+++ b/Target_HDDS.xml
@@ -24,17 +24,17 @@
 
   <composition name="Target">
     <posXYZ volume="targetSupportArm" X_Y_Z="0. 0. -70.461"/>
-    <posXYZ volume="targetVessel" X_Y_Z="0. 0. 0.0" />
+    <posXYZ volume="targetVessel" X_Y_Z="0. 0.3 0.0" rot="0.3 0.0 0.0" />
   </composition>
 
   <composition name="targetSupportArm" envelope="TARM">
     <posXYZ volume="TGB1" X_Y_Z="0. 0. -11.1916"/>
-    <posXYZ volume="TGB2" X_Y_Z="0. 0. +39.074"/>
+    <posXYZ volume="TGB2" X_Y_Z="0. 0. +38.824"/>
     <posXYZ volume="TGF1" X_Y_Z="0. 0. -48.9752"/>
     <posXYZ volume="TGF2" X_Y_Z="0. 0. -46.5325"/>
     <posXYZ volume="TGF3" X_Y_Z="0. 0. 28.1018"/>
     <posXYZ volume="TGF4" X_Y_Z="0. 0. 30.0068"/>
-    <posXYZ volume="TGF5" X_Y_Z="0. 0. 48.98"/>
+    <posXYZ volume="TGF5" X_Y_Z="0. 0. 48.88"/>
     <posXYZ volume="TGF6" X_Y_Z="0. 0. 24.9268"/>
     <posXYZ volume="TGR1" X_Y_Z="0. 0. 22.517"/>
     <posXYZ volume="TGR2" X_Y_Z="0. 0. -43.9"/>
@@ -51,7 +51,7 @@
     <polyplane Rio_Z="0.0 7.9375 28.7368"/>
     <polyplane Rio_Z="0.0 7.9375 31.2768"/>
     <polyplane Rio_Z="0.0 7.62   31.2768"/>
-    <polyplane Rio_Z="0.0 7.62   50.25"/>
+    <polyplane Rio_Z="0.0 7.62   50.15"/>
  </pcon>
 
  <pcon name="TGBM" material="Aluminum">
@@ -190,7 +190,7 @@
                                 comment="target vessel exit window" />
   <tubs name="TGB1" Rio_Z="9.8425 10.16 77.2668" material="Aluminum"
 	comment="Target arm beam pipe"/>
-  <tubs name="TGB2" Rio_Z="7.3025 7.62 22.352" material="Aluminum" 
+  <tubs name="TGB2" Rio_Z="7.3025 7.62 22.5" material="Aluminum" 
 	comment="Target arm beam pipe"/>
  <tubs name="TGF1" Rio_Z="10.16 22.5 1.7" material="StainlessSteel" 
        comment="flange"/>

--- a/Target_HDDS.xml
+++ b/Target_HDDS.xml
@@ -23,8 +23,8 @@
      liquid hydrogen target - not the start of the vacuum vessel.  -->
 
   <composition name="Target">
-    <posXYZ volume="targetSupportArm" X_Y_Z="0. 0. -71.221"/>
-    <posXYZ volume="targetVessel" X_Y_Z="0. 0. 15.424" />
+    <posXYZ volume="targetSupportArm" X_Y_Z="0. 0. -86.645"/>
+    <posXYZ volume="targetVessel" X_Y_Z="0. 0. 0.0" />
   </composition>
 
   <composition name="targetSupportArm" envelope="TARM">
@@ -65,13 +65,13 @@
   </pcon>
 
   <composition name="targetVessel" envelope="TARG">
-    <posXYZ volume="CYLW" X_Y_Z="0. 0. 0." />
-    <posXYZ volume="TGBM" X_Y_Z="0. 0. 0."/>
-    <posXYZ volume="DWIT" X_Y_Z="0. 0. +18.24505"/>
-    <posXYZ volume="TGR0" X_Y_Z="0. 0. -27.5015"/>
-    <posXYZ volume="TGR0" X_Y_Z="0. 0. -30.359"/>
-    <posXYZ volume="targetInput" X_Y_Z="0. 0. -1.608"/>
-    <posXYZ volume="targetTube" X_Y_Z="0. 0. -1.608" />
+    <posXYZ volume="CYLW" X_Y_Z="0. 0. 16.608" />
+    <posXYZ volume="TGBM" X_Y_Z="0. 0. 16.608"/>
+    <posXYZ volume="DWIT" X_Y_Z="0. 0. +34.8465"/>
+    <posXYZ volume="TGR0" X_Y_Z="0. 0. -12.5015"/>
+    <posXYZ volume="TGR0" X_Y_Z="0. 0. -15.359"/>
+    <posXYZ volume="targetInput" X_Y_Z="0. 0. 15.00"/>
+    <posXYZ volume="targetTube" X_Y_Z="0. 0. 15.00" rot="0.0076 0.004 0.0"/>
   </composition>
 
   <composition name="targetTube" envelope="TGTV">
@@ -162,19 +162,19 @@
   </pcon>
     
   <pcon name="TARG" material="Vacuum" comment="target vessel mother volume">
-    <polyplane Rio_Z="0. 7.62 -36.825"/>
-    <polyplane Rio_Z="0. 7.62 -35.585"/>
-    <polyplane Rio_Z="0. 6.35 -35.585"/>
-    <polyplane Rio_Z="0. 6.35 -24.975"/>
-    <polyplane Rio_Z="0. 4.118 -22.1565"/>
-    <polyplane Rio_Z="0. 4.699 -22.1565"/>
-    <polyplane Rio_Z="0. 4.699 +13.2435"/>
-    <polyplane Rio_Z="0.0 4.672 +14.2435"/>
-    <polyplane Rio_Z="0.0 4.453 +15.2435"/>
-    <polyplane Rio_Z="0.0 3.979 +16.2435"/>
-    <polyplane Rio_Z="0.0 3.135 +17.2435"/>
-    <polyplane Rio_Z="0.0 2.466 +17.7435"/>
-    <polyplane Rio_Z="0.0 1.905 +18.2514"/>
+    <polyplane Rio_Z="0. 7.62  -22.2234"/>
+    <polyplane Rio_Z="0. 7.62  -18.9834"/>
+    <polyplane Rio_Z="0. 6.35  -18.9834"/>
+    <polyplane Rio_Z="0. 6.35   -8.3734"/>
+    <polyplane Rio_Z="0. 4.118  -5.5549"/>
+    <polyplane Rio_Z="0. 4.699  -5.5549"/>
+    <polyplane Rio_Z="0. 4.699  29.8451"/>
+    <polyplane Rio_Z="0.0 4.672 30.8451"/>
+    <polyplane Rio_Z="0.0 4.453 31.8451"/>
+    <polyplane Rio_Z="0.0 3.979 32.8451"/>
+    <polyplane Rio_Z="0.0 3.135 33.8451"/>
+    <polyplane Rio_Z="0.0 2.466 34.3451"/>
+    <polyplane Rio_Z="0.0 1.905 34.853"/>
   </pcon>
 
   <tubs name="TGR0" Rio_Z="3.81 5.842 0.635" material="FR-4"/>

--- a/Target_HDDS.xml
+++ b/Target_HDDS.xml
@@ -70,8 +70,8 @@
     <posXYZ volume="DWIT" X_Y_Z="0. 0. +34.8465"/>
     <posXYZ volume="TGR0" X_Y_Z="0. 0. -12.5015"/>
     <posXYZ volume="TGR0" X_Y_Z="0. 0. -15.359"/>
-    <posXYZ volume="targetInput" X_Y_Z="0. 0. 15.00" rot="0.0076 0.004 0.0"/>
-    <posXYZ volume="targetTube" X_Y_Z="0. 0. 15.00" rot="0.0076 0.004 0.0"/>
+    <posXYZ volume="targetInput" X_Y_Z="0. 0. 15.00" rot="0.004 0.0076 0.0"/>
+    <posXYZ volume="targetTube" X_Y_Z="0. 0. 15.00" rot="0.004 0.0076 0.0"/>
   </composition>
 
   <composition name="targetTube" envelope="TGTV">

--- a/Target_HDDS.xml
+++ b/Target_HDDS.xml
@@ -29,12 +29,12 @@
 
   <composition name="targetSupportArm" envelope="TARM">
     <posXYZ volume="TGB1" X_Y_Z="0. 0. -11.1916"/>
-    <posXYZ volume="TGB2" X_Y_Z="0. 0. +38.644"/>
+    <posXYZ volume="TGB2" X_Y_Z="0. 0. +39.074"/>
     <posXYZ volume="TGF1" X_Y_Z="0. 0. -48.9752"/>
     <posXYZ volume="TGF2" X_Y_Z="0. 0. -46.5325"/>
     <posXYZ volume="TGF3" X_Y_Z="0. 0. 28.1018"/>
     <posXYZ volume="TGF4" X_Y_Z="0. 0. 30.0068"/>
-    <posXYZ volume="TGF5" X_Y_Z="0. 0. 48.55"/>
+    <posXYZ volume="TGF5" X_Y_Z="0. 0. 48.98"/>
     <posXYZ volume="TGF6" X_Y_Z="0. 0. 24.9268"/>
     <posXYZ volume="TGR1" X_Y_Z="0. 0. 22.517"/>
     <posXYZ volume="TGR2" X_Y_Z="0. 0. -43.9"/>
@@ -70,8 +70,8 @@
     <posXYZ volume="DWIT" X_Y_Z="0. 0. +34.8465"/>
     <posXYZ volume="TGR0" X_Y_Z="0. 0. -12.5015"/>
     <posXYZ volume="TGR0" X_Y_Z="0. 0. -15.359"/>
-    <posXYZ volume="targetInput" X_Y_Z="0. 0. 15.00" rot="0.004 0.0076 0.0"/>
-    <posXYZ volume="targetTube" X_Y_Z="0. 0. 15.00" rot="0.004 0.0076 0.0"/>
+    <posXYZ volume="targetInput" X_Y_Z="-0.018 -0.002 15.00" rot="0.004 0.0076 0.0"/>
+    <posXYZ volume="targetTube" X_Y_Z="-0.018 -0.002 15.00" rot="0.004 0.0076 0.0"/>
   </composition>
 
   <composition name="targetTube" envelope="TGTV">
@@ -91,7 +91,7 @@
   </pcon>
 
   <pcon name="LIH2" material="LiqHydrogen" comment="target contents">
-    <polyplane Rio_Z="0.0 0.29715 -14.9873"/>
+    <polyplane Rio_Z="0.0 0.29715 -14.9925"/>
     <polyplane Rio_Z="0.0 0.5040  -14.8162"/>
     <polyplane Rio_Z="0.0 0.72389  -14.5162"/>
     <polyplane Rio_Z="0.0 0.78359 -14.2162"/>
@@ -99,7 +99,7 @@
     <polyplane Rio_Z="0.0 0.78359 +14.2162"/>
     <polyplane Rio_Z="0.0 0.72389  +14.5162"/>
     <polyplane Rio_Z="0.0 0.5040  +14.8162"/>
-    <polyplane Rio_Z="0.0 0.29715 +14.9873"/>
+    <polyplane Rio_Z="0.0 0.29715 +14.9925"/>
     <real name="length" value="29.9746" unit="cm"/>
   </pcon>
 

--- a/main_HDDS.xml
+++ b/main_HDDS.xml
@@ -70,9 +70,9 @@
   <composition name="barrelPackage" envelope="LASS">
     <posXYZ volume="Solenoid" />
     <posXYZ volume="StartCntr" X_Y_Z="0.0 0.0 37.051"  rot="0.0 0.0 -11.25"/>
-    <posXYZ volume="CentralDC" X_Y_Z="0.003 -0.032 17.06" rot="-0.00115 0.01834 0.0455" />
-    <posXYZ volume="ForwardDC" X_Y_Z="0.0 0.0 176.9379" />
-    <posXYZ volume="BarrelEMcal" X_Y_Z="0.1 -0.098 16.788" />
+    <posXYZ volume="CentralDC" X_Y_Z="0.003 -0.032 17.06" rot="0.01834 -0.00115 0.0455" />
+    <posXYZ volume="ForwardDC" X_Y_Z="0.0 0.0 176.938" />
+    <posXYZ volume="BarrelEMcal" X_Y_Z="0.1 -0.098 16.788" rot="-0.0424 -0.01633 0.0046" />
   </composition>
 
   <composition name="forwardPackage">
@@ -80,8 +80,8 @@
     <!--posXYZ volume="GapEMcal" X_Y_Z="0.0 0.0 460.0" /-->
     <!-- To simulate DIRC hits uncomment the line below -->
     <!--posXYZ volume="DIRC" X_Y_Z="0.0 0.0 595.0" /-->
-    <posXYZ volume="ForwardTOF" X_Y_Z="0.308 0.225 605.793" rot="-0.0461 -0.0427 -0.1813"/>
-    <posXYZ volume="ForwardEMcal" X_Y_Z="0.529 -0.002 624.906" rot="0.07019 -0.0418 -0.0149" />
+    <posXYZ volume="ForwardTOF" X_Y_Z="0.308 0.225 605.793" rot="-0.0427 -0.0461 -0.1813"/>
+    <posXYZ volume="ForwardEMcal" X_Y_Z="0.529 -0.002 624.906" rot="-0.0418 0.07019 -0.0149" />
     <!--posXYZ volume="ComptonEMcal" X_Y_Z="0.0 0.0 1025.3" /-->
   </composition>
 

--- a/main_HDDS.xml
+++ b/main_HDDS.xml
@@ -69,10 +69,10 @@
 
   <composition name="barrelPackage" envelope="LASS">
     <posXYZ volume="Solenoid" />
-    <posXYZ volume="StartCntr" X_Y_Z="0.0 0.0 37.551"  rot="0.0 0.0 -11.25"/>
-    <posXYZ volume="CentralDC" X_Y_Z="0.0 0.0 17.56" />
-    <posXYZ volume="ForwardDC" X_Y_Z="0.0 0.0 177.4379" />
-    <posXYZ volume="BarrelEMcal" X_Y_Z="0.0 0.0 17.0" />
+    <posXYZ volume="StartCntr" X_Y_Z="0.0 0.0 37.051"  rot="0.0 0.0 -11.25"/>
+    <posXYZ volume="CentralDC" X_Y_Z="0.003 -0.032 17.06" rot="-0.00115 0.01834 0.0455" />
+    <posXYZ volume="ForwardDC" X_Y_Z="0.0 0.0 176.9379" />
+    <posXYZ volume="BarrelEMcal" X_Y_Z="0.1 -0.098 16.788" />
   </composition>
 
   <composition name="forwardPackage">
@@ -80,9 +80,9 @@
     <!--posXYZ volume="GapEMcal" X_Y_Z="0.0 0.0 460.0" /-->
     <!-- To simulate DIRC hits uncomment the line below -->
     <!--posXYZ volume="DIRC" X_Y_Z="0.0 0.0 595.0" /-->
-    <posXYZ volume="ForwardTOF" X_Y_Z="0.0 0.0 606.293" />
-    <posXYZ volume="ForwardEMcal" X_Y_Z="0.0 0.0 625.406" />
-    <posXYZ volume="ComptonEMcal" X_Y_Z="0.0 0.0 1025.3" />
+    <posXYZ volume="ForwardTOF" X_Y_Z="0.308 0.225 605.793" rot="-0.0461 -0.0427 -0.1813"/>
+    <posXYZ volume="ForwardEMcal" X_Y_Z="0.529 -0.002 624.906" rot="0.07019 -0.0418 -0.0149" />
+    <!--posXYZ volume="ComptonEMcal" X_Y_Z="0.0 0.0 1025.3" /-->
   </composition>
 
   <composition name="backwardPackage">
@@ -90,7 +90,8 @@
   </composition> 
 
   <composition name="GlueXdetector">
-    <posXYZ volume="Target" X_Y_Z="0.0 0.0 50.0" />
+    <!--The following is the position of the entrance window of the target cell-->
+    <posXYZ volume="Target" X_Y_Z="0.0 0.0 48.316" />
     <posXYZ volume="barrelPackage" />
     <posXYZ volume="forwardPackage" />
 <!-- removed from standard geometry 12/11/2007 -rtj
@@ -100,9 +101,9 @@
 
   <composition name="experimentalHall" envelope="HALL">
     <posXYZ volume="GlueXdetector" X_Y_Z="150.0 -350.0 -500.0" />
-    <posXYZ volume="PairSpectrometer" X_Y_Z="150.0 -350.0 -1389.66" />  
-    <posXYZ volume="beamPipe" X_Y_Z="0.0 0.0 0.0" />
-    <posXYZ volume="SixWayCross" X_Y_Z="150 -350 -605.43"/>
+    <posXYZ volume="PairSpectrometer" X_Y_Z="150.0 -350.0 -1390.16" />  
+    <posXYZ volume="beamPipe" X_Y_Z="0.0 0.0 -0.5" />
+    <posXYZ volume="SixWayCross" X_Y_Z="150 -350 -605.93"/>
   </composition>
 
   <composition name="LASSfieldVolume">
@@ -110,7 +111,7 @@
   </composition>
 
   <composition name="everything" envelope="SITE">
-    <posXYZ volume="collimatorPackage" X_Y_Z="0.0 0.0 -2254." />
+    <posXYZ volume="collimatorPackage" X_Y_Z="0.0 0.0 -2254.5" />
     <posXYZ volume="LASSfieldVolume" X_Y_Z="0. 0. 0." />
   </composition>
 

--- a/main_HDDS.xml
+++ b/main_HDDS.xml
@@ -68,11 +68,12 @@
   </box>
 
   <composition name="barrelPackage" envelope="LASS">
-    <posXYZ volume="Solenoid" />
-    <posXYZ volume="StartCntr" X_Y_Z="0.0 0.0 37.051"  rot="0.0 0.0 -11.25"/>
-    <posXYZ volume="CentralDC" X_Y_Z="0.003 -0.032 18.04" rot="0.01834 -0.00115 0.0455" />
+    <posXYZ volume="Solenoid" X_Y_Z="0.03 0.0 0.0"/>
+    <posXYZ volume="Target" X_Y_Z="0.0 0.0 48.316"/>
+    <posXYZ volume="StartCntr" X_Y_Z="0.0 0.0 37.12"  rot="0.0 0.0 -11.25"/>
+    <posXYZ volume="CentralDC" X_Y_Z="0.0 -0.080 17.68" rot="0.0218 0.008 0.045" />
     <posXYZ volume="ForwardDC" X_Y_Z="0.0 0.0 176.938" />
-    <posXYZ volume="BarrelEMcal" X_Y_Z="0.1 -0.098 16.788" rot="-0.0424 -0.01633 0.0046" />
+    <posXYZ volume="BarrelEMcal" X_Y_Z="0.1 -0.098 16.788" rot="-0.0424 0.01633 0.0046" />
   </composition>
 
   <composition name="forwardPackage">
@@ -80,8 +81,8 @@
     <!--posXYZ volume="GapEMcal" X_Y_Z="0.0 0.0 460.0" /-->
     <!-- To simulate DIRC hits uncomment the line below -->
     <!--posXYZ volume="DIRC" X_Y_Z="0.0 0.0 595.0" /-->
-    <posXYZ volume="ForwardTOF" X_Y_Z="0.308 0.225 605.793" rot="-0.0427 -0.0461 -0.1813"/>
-    <posXYZ volume="ForwardEMcal" X_Y_Z="0.529 -0.002 624.906" rot="-0.0418 0.07019 -0.0149" />
+    <posXYZ volume="ForwardTOF" X_Y_Z="0.308 0.225 605.793" rot="-0.0427 0.0461 -0.1813"/>
+    <posXYZ volume="ForwardEMcal" X_Y_Z="0.529 -0.002 624.906" rot="-0.0418 -0.07019 -0.0149" />
     <!--posXYZ volume="ComptonEMcal" X_Y_Z="0.0 0.0 1025.3" /-->
   </composition>
 
@@ -91,7 +92,7 @@
 
   <composition name="GlueXdetector">
     <!--The following is the position of the entrance window of the target cell-->
-    <posXYZ volume="Target" X_Y_Z="0.0 0.0 48.316" />
+    <!--posXYZ volume="Target" X_Y_Z="0.0 0.0 48.316" /> Moved the target to the LASS volume SJT 6/2/2016 -->
     <posXYZ volume="barrelPackage" />
     <posXYZ volume="forwardPackage" />
 <!-- removed from standard geometry 12/11/2007 -rtj

--- a/main_HDDS.xml
+++ b/main_HDDS.xml
@@ -62,7 +62,7 @@
 
   <box name="SITE" X_Y_Z="5000. 5000. 5000." material="Air"
        				comment="master volume for description" />
-  <box name="HALL" X_Y_Z="1700. 1500. 3408." material="Air"
+  <box name="HALL" X_Y_Z="1700. 1500. 3409." material="Air"
        				comment="master volume for description">
     <apply region="solenoidBfield" origin="150.0 -350.0 -500.0" />
   </box>

--- a/main_HDDS.xml
+++ b/main_HDDS.xml
@@ -70,7 +70,7 @@
   <composition name="barrelPackage" envelope="LASS">
     <posXYZ volume="Solenoid" />
     <posXYZ volume="StartCntr" X_Y_Z="0.0 0.0 37.051"  rot="0.0 0.0 -11.25"/>
-    <posXYZ volume="CentralDC" X_Y_Z="0.003 -0.032 17.06" rot="0.01834 -0.00115 0.0455" />
+    <posXYZ volume="CentralDC" X_Y_Z="0.003 -0.032 18.04" rot="0.01834 -0.00115 0.0455" />
     <posXYZ volume="ForwardDC" X_Y_Z="0.0 0.0 176.938" />
     <posXYZ volume="BarrelEMcal" X_Y_Z="0.1 -0.098 16.788" rot="-0.0424 -0.01633 0.0046" />
   </composition>


### PR DESCRIPTION
Numerous changes to xml based on the latest  (May 2016) survey.  CDC needed to be moved downstream relative to the old survey result by about 5.5 mm and the start counter is offset in y by 3.4 mm and rotated towards the beam line.  These two changes required many adjustments to avoid overlaps.   I also added gaps between the TOF paddles.
