### PR TITLE
* hddsCommon.cpp, hddsCommon.hpp [rtj]

### DIFF
--- a/hddsCommon.cpp
+++ b/hddsCommon.cpp
@@ -183,7 +183,7 @@ Refsys::Refsys(const Refsys& src)	// copy constructor
    reset(src);
 }
 
-Refsys& Refsys::operator=(Refsys& src)	// copy operator (deep sematics)
+Refsys& Refsys::operator=(const Refsys& src)	// copy operator (deep sematics)
 {
    fIdentifier = src.fIdentifier;
    fMother = src.fMother;
@@ -200,7 +200,7 @@ Refsys& Refsys::operator=(Refsys& src)	// copy operator (deep sematics)
       fMRmatrix[i][1] = src.fMRmatrix[i][1];
       fMRmatrix[i][2] = src.fMRmatrix[i][2];
    }
-   std::map<std::string,double>::iterator iter;
+   std::map<std::string,double>::const_iterator iter;
    for (iter = src.fPar.begin(); iter != src.fPar.end(); ++iter)
    {
       fPar[iter->first] = iter->second;

--- a/hddsCommon.hpp
+++ b/hddsCommon.hpp
@@ -115,7 +115,7 @@ class Refsys
 
    Refsys();				// empty constructor
    Refsys(const Refsys& src);		// copy constructor
-   Refsys& operator=(Refsys& src);	// copy operator
+   Refsys& operator=(const Refsys& src);	// copy operator
    Refsys& reset();			// reset origin, Rmatrix
    Refsys& reset(const Refsys& ref);	// reset origin, Rmatrix to ref
    Refsys& shift(const double vector[3]); // translate origin


### PR DESCRIPTION
   - attempt to fix compiler error in gcc 6.2.1 reported by Mark Ito,
     related to attempt to use a non-const rvalue to initialize a
     Refsys& reference, proposed solution is to make the argument
     const.