### PR TITLE
* BeamLine_HDDS.xml [rtj]

### DIFF
--- a/BeamLine_HDDS.xml
+++ b/BeamLine_HDDS.xml
@@ -184,7 +184,7 @@
     <posXYZ volume="ConcreteWall2" X_Y_Z="0.0  33.0  941.24" />
     <posXYZ volume="shieldingWall" X_Y_Z="0.0  35.0 1004.74" />     
     <!-- <posXYZ volume="TargetBox"     X_Y_Z="50.0  0.0 1085.00" /> -->
-    <posXYZ volume="BeamPipe2"     X_Y_Z="0.0  0.0  1071.14" />
+    <posXYZ volume="BeamPipe2"     X_Y_Z="0.0  0.0  1066.146" />
   </composition>
 
 <!-- Beam Pipe 0 -->
@@ -788,7 +788,7 @@ This construction is not in use at the present time
   </composition>
   
   <composition name="BeamPipe2Inner" envelope="BPI2">
-    <posXYZ volume="photonBeamHarp" X_Y_Z="0.0 0.0 -32.42" />
+    <posXYZ volume="photonBeamHarp" X_Y_Z="0.0 0.0 -27.38" />
   </composition>
   
   <composition name="photonBeamHarp">
@@ -796,8 +796,8 @@ This construction is not in use at the present time
     <posXYZ volume="PSCH" />
   </composition>
 
-  <tubs name="BPO2" Rio_Z="0.0  2.54   127.72" material="Iron" />
-  <tubs name="BPI2" Rio_Z="0.0  2.38   127.72" material="Vacuum" />
+  <tubs name="BPO2" Rio_Z="0.0  2.54   117.723" material="Iron" />
+  <tubs name="BPI2" Rio_Z="0.0  2.38   117.723" material="Vacuum" />
 
   <composition name="PairSpecConverter" envelope="PSCM">
     <posXYZ volume="PSCV"/>

--- a/Regions_HDDS.xml
+++ b/Regions_HDDS.xml
@@ -26,12 +26,13 @@
 
   <region name="PairBfield"
           comment="photon beam pair spetrometer">
+    <!-- use the line below to get a uniform field, useful for debugging 
     <uniformBfield Bx_By_Bz="0  16.4  0" unit="kG"/>
+    -->
 
-    <!--  hook to use field loaded from CCDB
+    <!--  hook to use field loaded from CCDB-->
     <computedBfield function="gufld_ps(r,B)" maxBfield="2.5" unit="T"/>
     <swim method="RungeKutta"/>
-    -->
   </region>
 
 


### PR DESCRIPTION
   - shorted the BeamPipe2 volume to take off 10.07 cm of overlap with
     the pair spectrometer vacuum box. Shift the center of BeamPipe2
     where it is placed to reflect this change in length. Before this,
     we had overlap between a beam pipe without magnetic field inside
     and the dipole vacuum box with magnetic field inside, which I
     found because geant3 and geant4 were in disagreement about the
     magnetic field integral along the beamline. Fix this.

* Regions_HDDS.xml [rtj]
   - change from a uniform Bfield inside the pair spectrometer dipole
     to look up the field in the ccdb field map.