### PR TITLE
* BeamLine_HDDS.xml [rtj]

### DIFF
--- a/BeamLine_HDDS.xml
+++ b/BeamLine_HDDS.xml
@@ -239,12 +239,20 @@
 
   <composition name="TungstenInsert" envelope="PCTT">
     <posXYZ volume="PCTH" X_Y_Z="0.0 0.0 0.0" />
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.02865 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.05730 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.11459 0 0" /-->
+  </composition>
+  <composition name="PrimaryCollimatorAperture" envelope="PCTH">
+    <posXYZ volume="PCTI" X_Y_Z="0.0 0.0 -5.0" />
   </composition>
 
   <box  name="PCTT"  X_Y_Z="5.08   5.08   20." material="Tungsten" />
   <!--tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" /-->
-  <!-- Wider collimator diameter for commissioning -->
   <tubs name="PCTH"  Rio_Z="0.0    0.25   20." material="Air" />
+  <tubs name="PCTI"  Rio_Z="0.05   0.25   10." material="Tungsten" 
+        comment="pin-hole insert for reduced intensity running" />
 
 
 <!-- Flange 1 -->
@@ -830,10 +838,12 @@ This construction is not in use at the present time
     <!--posXYZ volume="DET8" X_Y_Z="150 -350.0 -834.0 "/-->
   </composition>
 
-<!--  <box name="DET4" X_Y_Z="1700.0  1200.0  2.0" material="Vacuum" /> -->
+  <box name="DET4" X_Y_Z="1700.0  1200.0  2.0" material="Vacuum" />
   <box name="DET5" X_Y_Z="1700.0  1198.0  2.0" material="Air" />
   <box name="DET6" X_Y_Z="1700.0  2.0  3000.0" material="Air" />
-  <box name="DET7" X_Y_Z="1700.0  1198.0  2.0" material="Air" />
+  <!--box name="DET7" X_Y_Z="1700.0  1198.0  2.0" material="Air" /-->
+  <tubs name="DET7" Rio_Z="0.0 1.7399  2.0" material="Vacuum"
+        comment="disk detector inside beam pipe at target entrance" />
   <box name="DET8" X_Y_Z="10.0 10.0 1.0" material="Scintillator" sensitive="true"/>
 
 <!-- Hall bellows -->
@@ -860,13 +870,14 @@ This construction is not in use at the present time
 
 <!-- Hall Pipe -->
   <composition name="HallPipe" envelope="OHPI" >
-    <posXYZ volume="IHPI" X_Y_Z="0 0 98.6305"/>
-    <!---posXYZ volume="InnerHallPipe" X_Y_Z="0.0 0.0 0.0"/--> 
+    <!--posXYZ volume="IHPI" X_Y_Z="0 0 98.6305"/-->
+    <posXYZ volume="InnerHallPipe" X_Y_Z="0.0 0.0 98.6305"/> 
   </composition>
 
-  <!--composition name="InnerHallPipe" envelope="IHPI" >
-    <posXYZ volume="CAP1" X_Y_Z="0.0  0.0  190.11265" />
-  </composition-->
+  <composition name="InnerHallPipe" envelope="IHPI">
+    <posXYZ volume="DET7" X_Y_Z="0 0 280.0"/> 
+    <!--posXYZ volume="CAP1" X_Y_Z="0.0  0.0  190.11265" /-->
+  </composition>
 
 
   <pcon name="OHPI" material="Iron">

--- a/HDDS-1_1.xsd
+++ b/HDDS-1_1.xsd
@@ -767,7 +767,7 @@
 
         name      : a short descriptive ID of this field region
         modifies  : name of another region to provide default values
-       comment   : a more verbose description
+        comment   : a more verbose description
 
   The region name must be a NMTOKEN type (begin with a letter, contain
   alphanumeric characters and underscores, and contain no spaces) like


### PR DESCRIPTION
   - change DET7 to a small disk of vacuum that fits inside the photon
     beam pipe just upstream of the entrance to the liquid hydrogen
     target. When the beampipe was extended all the way to the flange
     at the entrance to the target, DET7 got commented out, but I still
     need it in order to profile the collimated beam at the target.
   - add capability to insert a narrow (1.08mm) pin-hole collimator
     insert into the primary collimator. It is there in the geometry
     but presently commented out in the distributed xml.

* HDDS-1_1.xsd [rtj]
   - fix an alignment issue in the documentation