### PR TITLE
- introduce custom BeamLine_HDDS.xml versions, depending on

### DIFF
--- a/BeamLine_HDDS_0_0.xml
+++ b/BeamLine_HDDS_0_0.xml
@@ -1,0 +1,1642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DOCTYPE HDDS>
+
+  Hall D Geometry Data Base: Beam Line
+  ************************************
+
+     version 1.0: Initial version	-rtj
+
+     Revision 1.1 10/18/2002 
+     -added concrete shielding to the collimator housing 
+     -added the virtual detectors to this code:
+        DET1: disk intercepting entire beam upstream of collimators
+        DET2: plane perpendicular to beam just after second collimator
+        DET3: plane mounted just below the ceiling of collimator cave
+        DET4: plane perpendicular to beam just after entry to hall
+        DET5: plane perpendicular to beam at photon dump end of hall
+        DET6: plane mounted just below the ceiling inside the hall
+        DET7: plane perpendicular to beam just before the target
+     -added a steel tube containing a vacuum that goes from the back of
+      the collimator to the front of the solenoid  
+     -csg-
+
+     Revision 1.2 10/28/2002
+     -revised collimator to the heavy shielding option 
+     -added a steel tube containing a vacuum in the WALL, SHLD and ABS2 volumes
+     -repositioned DET3 to be inside the collimator housing 
+     -removed the BEAM volume from the collimator system
+     -csg-
+
+     Revision 1.3 1/9/2003
+     -shrunk the size of the vacuum tube from r=5.3 to r=2.5 in order to
+      extend the tube into the second steering magnet
+     -csg-
+
+     Revision 1.4 06/16/2003
+     -mid-shielding option
+     -modified DET1, now a cylinder placed in front of primary collimator
+     -added tungsten pin-cushion detector model into simulation
+     -csg- 
+
+     Revision 2.0 05/16/2008
+     -moved DET2 to just after the second collimator, in agreement with
+      the comments below.  Somehow it got misplaced to upstream of the
+      second collimator.  I guess no one was using it until now.
+     -added the volume CONV for the pair conversion target located inside
+      the vacuum pipe just downstream of the second sweep magnet.  Right
+      now it its material is vacuum, but the thickness of 240 microns is
+      chosen to make a 0.1% converter if the material is set to Carbon.
+
+
+     Revision 2.1  12/12/2008, A.S., rtj
+       Made the following changes in the composition 'collimatorStack':
+  	  1. Added the composition BeamPipe0 describing a vacuum beam pipe at the entrance 
+             of the collimator cave:
+              - the beam pipe radius is 12.4 cm
+              - the exit window: 250 micron Kapton with the radius of 10.14 cm. 
+ 	  2. Moved the active collimator, DET1, and other components 83.96 cm upstream the 
+             beamline.
+          3. Changed layout of the 1st passive collimator to a composite W/Pb:
+	      - the inner part is a W  box,  5.08 x  5.08 x 20.0 cm3
+              - the outer part is a Pb box, 30.48 x 30.48 x 20.0 cm3 
+          4. Added  the vacuum beam pipe (Flange1 compositon) in front of the 1st sweeping 
+             magnet:
+              - use 150 micron Kapton entrance window
+              - vaccuum goes all the way downstream the beamline until the GlueX detector.
+          5. Modified the layout of the 1st sweeping magnet:
+              - the outer dimensions are 29.2 x 24.8 x 355.6 cm3
+              - the gap size is 10.22 x 4.9 cm2 
+              - the field inside the gap is 0.23 T (integrated field is 0.82 Tm)
+              - the elliptical vacuum pipe goes through the magnet. The semi-axes of the pipe 
+              are 4.95 cm and 2.29 cm.        
+          6. Added the concrete blocks around the 1st sweeping magnet, composition ConcreteWall1. 
+             The size of the wall is 101.6 x 147.32 x 121.92 cm3.
+          7. Added the composition Flange2 to connect the 1st sweeping magnet with a vacuum chamber.
+          8. Added a vacuum chamber after the 1st sweeping magnet with the following dimensions:
+              - 50.8 cm long tube with the inner and outer radii of Rin = 9.83 cm and Rout = 9.85.
+          9. Added the small lead wall after the vacuum chamber, composition LeadBand1.
+         10. Added the composition Flange3 to connect the vacuum pipe between the lead band and the
+             2nd collimatoor.
+         11. Changed material of the 2nd collimator from Nickel to Iron. The default pinhole 
+             diameter was changed from 1 cm to 0.6 cm.
+         12. Added the composition Flange4 to connect the vacuum pipe between the 2nd collimator and
+             the 2nd sweeping magnet.
+         13. Changed the layout of the second sweeping magnet:
+              - outer dimensions are 42 x 20.8 cm2
+              - the gap size is 20.3 x 5 cm2, the field in the gap is 0.23 T
+              - 1.75 cm radius vacuum beam pipe goes through the magnet.         
+         14. Added the composition Flange5 to connect 2nd the sweeping magnet with the vacuum beam 
+             pipe.           
+         15. Added a 1m long vacuum beam pipe. The inner and outer radii are 2.38 and 2.54 cm, 
+             respectively.
+         16. Added the small lead wall (composition LeadBand2), 81.28 x 20.32 x 10.16 cm3.
+         17. Placed the vertical plane DET2 after the lead wall. 
+         18. Added the composition Flange6 to connect the vacuum pipe between the lead wall and 
+             a pair spectrometer converter box.          
+         19. Added the pair spectrometer converter. The converter thickness and material can be set
+             in the box 'PTAR'   <box  name="PTAR" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />.
+         20. Added the composition Flange7 to connect the vacuum pipe between the converter and 
+             the concrete wall.
+         21. Modified the size of the concrete shielding wall to 450.0 x 270.0 x 121.92 cm3.
+             Added passage to the collimator cave.
+         22. Decreased thickness of the lead wall to 5.08 cm (size of the lead brick).
+              
+     Revision 2.2  12/22/2008
+       Modified the composition 'beamPipe'. Now 'beamPipe' extends the vacuum from the 
+       pair spectrometer to the position of the target.
+
+     Revision 3.0  3/2/2011
+       Large group of revisions, to reflect the beamline geometry and shielding
+       in the engineering drawings for the cave, and the new pair spectrometer.
+
+     Revision 3.1 9/6/2013
+       Updates for compatibility with geant4 -rtj
+       a) Many small shifts to various volumes to eliminate overlaps.
+       b) Changes to dimensions of the active collimator wedges, and even
+          the number of pins per row, so that all overlaps are eliminated.
+
+     Revision 3.2 12/12/2016
+       Updates to introduce the triplet polarimeter -rtj
+       a) renamed downstream PS converter target from PTAR to CONV
+       b) reserved the name PTAR for the triplet polarimeter target
+       c) incorporated a detailed geometric model of the triplet polarimeter
+          from the ASU group into the beamline geometry
+
+     Revision 3.3 3/27/2017
+     Added TAC and some material downstream the FCAL - A.S. 
+     - FCAL dark box window, FCAL platform pipe with plexiglass window, beam 
+     - intensity monitor, and TAC
+
+
+
+<HDDS specification="v1.0" xmlns="http://www.gluex.org/hdds">
+-->
+
+<section name        = "BeamLine"
+         version     = "3.2"
+         date        = "2016-12-12"
+         author      = "R.T. Jones"
+         top_volume  = "collimatorPackage"
+         specification = "v1.0">
+
+<!-- Origin of collimatorPackage is center of the entrance face of the
+     primary collimator.  					-->
+
+  <composition name="collimatorPackage">
+    <posXYZ volume="ShieldedCollimator" X_Y_Z="0.0  0.0  400.0" />
+  </composition>
+
+  <box name="SHLD" X_Y_Z="550.  550.  1300." material="Concrete"/>
+  <composition name="ShieldedCollimator" envelope="SHLD">
+    <posXYZ volume="pipeFromTaggerHall" X_Y_Z="0.0  0.0  -625.0" />
+    <posXYZ volume="collimatorCave" X_Y_Z="0.0  35.0  25.0" />
+  </composition>  
+ 
+  <box  name="CAVE" X_Y_Z="450. 270. 1250." material="Air" />
+  <composition name="collimatorCave" envelope="CAVE">
+    <posXYZ volume="collimatorStack" X_Y_Z="0.0 -35.0 -500.0"/>     
+<!--  <posXYZ volume="DET2" X_Y_Z="0.0  0.0  225.0" /> -->
+    <posXYZ volume="DET3" X_Y_Z="0.0  132.0  0.0" />
+  </composition>
+ 
+  <composition name="collimatorSubCave">
+    <posXYZ volume="collimatorStack" />
+  </composition>
+
+  <composition name="collimatorStack">
+    <posXYZ volume="BeamPipe0"     X_Y_Z="0.0  0.0  -125.0"  />
+    <!--posXYZ volume="PFLD"          X_Y_Z="0.0  0.0  -99.0"  />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -97.0"   />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -93.0"   /-->
+    <posXYZ volume="DET1"          X_Y_Z="0.0  0.0  -49.46"  />
+    <posXYZ volume="ColDetector"   X_Y_Z="0.0  0.0  -46.16"  />
+    <posXYZ volume="PrimaryCol"    X_Y_Z="0.0  0.0  -33.96"  />
+    <posXYZ volume="Flange1"       X_Y_Z="0.0  0.0   11.52"  />
+    <posXYZ volume="sweepMagnet1"  X_Y_Z="0.0  0.0   189.32" />
+    <posXYZ volume="ConcreteWall1" X_Y_Z="0.0  0.0   107.96" />
+    <posXYZ volume="Flange2"       X_Y_Z="0.0  0.0   367.12" />
+    <posXYZ volume="VacuumChamber" X_Y_Z="0.0  0.0   426.54" />
+    <posXYZ volume="LeadBand1"     X_Y_Z="0.0  0.0   457.02" />
+    <posXYZ volume="Flange3"       X_Y_Z="0.0  0.0   462.10" />
+    <posXYZ volume="COL2"          X_Y_Z="0.0  0.0   555.04" />
+    <posXYZ volume="Flange4"       X_Y_Z="0.0  0.0   580.44" />
+    <posXYZ volume="sweepMagnet2"  X_Y_Z="0.0  0.0   630.28" />
+    <posXYZ volume="Flange5"       X_Y_Z="0.0  0.0   648.28" />
+    <posXYZ volume="BeamPipe1"     X_Y_Z="0.0  0.0   712.28" />
+    <posXYZ volume="LeadBand2"     X_Y_Z="0.0  0.0   743.52" />
+    <posXYZ volume="DET2"          X_Y_Z="0.0  35.0  748.65" /> 
+    <posXYZ volume="Flange6"       X_Y_Z="0.0  0.0   748.70" />
+    <posXYZ volume="TripletPolar"  X_Y_Z="0.0 0.0    820.00" />
+    <posXYZ volume="Flange7"       X_Y_Z="0.0  0.0   840.954" />
+    <posXYZ volume="ConcreteWall2" X_Y_Z="0.0  33.0  941.24" />
+    <posXYZ volume="shieldingWall" X_Y_Z="0.0  35.0 1004.74" />     
+    <!--    <posXYZ volume="TargetBox"     X_Y_Z="0.0  0.0 1085.00" />   -->
+    <posXYZ volume="BeamPipe2"     X_Y_Z="0.0  0.0  1066.668" /> 
+  </composition>
+  
+<!-- Beam Pipe 0 -->
+
+  <composition name="pipeFromTaggerHall" envelope="PFTH">
+    <posXYZ volume="PFTV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PFTH" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="PFTV" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipe0">
+    <posXYZ volume="BeamPipeTube"    X_Y_Z="0.0  0.0  25.0" />
+    <posXYZ volume="BeamPipeFlange1" X_Y_Z="0.0  0.0  48.58" />
+    <posXYZ volume="BeamPipeExitWindow" X_Y_Z="0.0  0.0  50.0" />
+    <posXYZ volume="BeamPipeFlange2" X_Y_Z="0.0  0.0  51.42"  />
+  </composition>
+
+  <composition name="BeamPipeTube" envelope="BPTO">
+    <posXYZ volume="BPTI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPTO" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="BPTI" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipeFlange1">
+    <posXYZ volume="BFO1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BFO1" Rio_Z="12.7   15.24  2.84" material="Iron" />
+
+  <composition name="BeamPipeExitWindow">
+    <posXYZ volume="FCAP" X_Y_Z="0.0  0.0  0.0125"/>
+  </composition>
+
+  <tubs name="FCAP" Rio_Z="0.0   10.16   0.025" material="Kapton" />
+
+  <composition name="BeamPipeFlange2">
+    <posXYZ volume="BFO2" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="BFO2" Rio_Z="10.16   15.24   2.84"  material="Iron" />
+
+
+<!-- Primary Collimator -->
+
+  <composition name="PrimaryCol" envelope="PCPB">
+    <posXYZ volume="TungstenInsert" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="PCPB"  X_Y_Z="30.48  30.48  20." material="Lead" />
+
+  <composition name="TungstenInsert" envelope="PCTT">
+    <posXYZ volume="PCTH" X_Y_Z="0.0 0.0 0.0" />
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.02865 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.05730 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.11459 0 0" /-->
+  </composition>
+  <composition name="PrimaryCollimatorAperture" envelope="PCTH">
+    <posXYZ volume="PCTI" X_Y_Z="0.0 0.0 -5.0" />
+  </composition>
+
+  <box  name="PCTT"  X_Y_Z="5.08   5.08   20." material="Tungsten" />
+  <!--tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" /-->
+  <tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Tungsten" />
+  <tubs name="PCTI"  Rio_Z="0.05   0.25   10." material="Tungsten" 
+        comment="pin-hole insert for reduced intensity running" />
+
+
+<!-- Flange 1 -->
+
+  <composition name="Flange1">
+    <posXYZ volume="FlangeOneDisk" X_Y_Z="0.0  0.0  -7.72" />
+    <posXYZ volume="FlangeOneWindow" X_Y_Z="0.0  0.0  -6.65" />
+    <posXYZ volume="FlangeOnePipe" X_Y_Z="0.0  0.0  -3.325" />
+  </composition>
+
+  <composition name="FlangeOneDisk">
+    <posXYZ volume="FOI1" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="FOI1" Rio_Z="1.27  8.57  2.14"  material="Iron" />
+
+  <composition name="FlangeOneWindow">
+    <posXYZ volume="F1CP" X_Y_Z="0.0  0.0  -0.0075"/>
+  </composition>
+
+  <tubs name="F1CP" Rio_Z="0.0   1.27  0.015" material="Kapton" />
+
+  <composition name="FlangeOnePipe" envelope="FOPO">
+    <posXYZ volume="FOPI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FOPO" Rxy_Z="5.11  2.45   6.65" material="Iron" />
+  <eltu name="FOPI" Rxy_Z="4.95  2.29   6.65" material="Vacuum" />
+
+
+<!-- 1st Sweeping Magnet -->
+
+  <composition name="sweepMagnet1" envelope="MAG1">
+    <posXYZ volume="POL1" X_Y_Z="0.0 +7.425 0.0" />
+    <posXYZ volume="POL1" X_Y_Z="0.0 -7.425 0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="-9.855 0.0  0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="+9.855 0.0  0.0" />
+    <posXYZ volume="MagnetPipe1" X_Y_Z="0.0  0.0  0.0" />
+  </composition> 
+
+  <box name="MAG1" X_Y_Z="29.2 24.8 355.6" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <box name="POL1" X_Y_Z="29.2  9.95  355.6" material="Iron" />
+  <box name="GAP1" X_Y_Z="9.49  4.9   355.6" material="Iron" />
+
+  <composition name="MagnetPipe1" envelope="MPO1">
+    <posXYZ volume="MPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="MPO1" Rxy_Z="5.11  2.45  355.6" material="Iron" />
+  <eltu name="MPI1" Rxy_Z="4.95  2.29  355.6" material="Vacuum" />
+
+
+<!-- Concrete Wall around the 1st sweeping magnet -->
+
+  <composition name="ConcreteWall1">
+    <posXYZ volume="WTOP" X_Y_Z="0.0   +30.3  0.0" />
+    <posXYZ volume="WBOT" X_Y_Z="0.0   -56.2  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="+32.7   0.0  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="-32.7   0.0  0.0" />
+  </composition> 
+
+  <box name="WTOP" X_Y_Z="101.6  35.8  121.92" material="Concrete" />
+  <box name="WBOT" X_Y_Z="101.6  87.6  121.92" material="Concrete" />
+  <box name="WSID" X_Y_Z="36.2   24.8  121.92" material="Concrete" />
+
+
+<!-- Flange 2 -->
+
+  <composition name="Flange2">
+    <posXYZ volume="FlangeTwoDisk1" X_Y_Z="0.0  0.0  2.29" />
+    <posXYZ volume="FlangeTwoDisk2" X_Y_Z="0.0  0.0  6.72"/>
+    <posXYZ volume="FlangeTwoDisk3" X_Y_Z="0.0  0.0  16.88"/>
+    <posXYZ volume="FlangeTwoDisk4" X_Y_Z="0.0  0.0  27.04"/>
+    <posXYZ volume="FlangeTwoDisk5" X_Y_Z="0.0  0.0  31.6"/>
+  </composition>
+
+  <composition name="FlangeTwoDisk1" envelope="FTO1">
+    <posXYZ volume="FTI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FTO1" Rxy_Z="5.11  2.45   4.58" material="Iron" />
+  <eltu name="FTI1" Rxy_Z="4.95  2.29   4.58" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk2" envelope="FTO2">
+    <posXYZ volume="FTI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO2" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI2" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk3" envelope="FTO3">
+    <posXYZ volume="FTI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO3" Rio_Z="0.0  6.21  16.04" material="Iron" />   
+  <tubs name="FTI3" Rio_Z="0.0  6.19  16.04" material="Vacuum" /> 
+
+  <composition name="FlangeTwoDisk4" envelope="FTO4">
+    <posXYZ volume="FTI4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO4" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI4" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk5" envelope="FTO5">
+    <posXYZ volume="FTI5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO5" Rio_Z="0.0  6.35   4.84" material="Iron" />
+  <tubs name="FTI5" Rio_Z="0.0  6.19   4.84" material="Vacuum" />
+
+
+<!-- Vacuum chamber after the 1st sweeping magnet-->
+
+  <composition name="VacuumChamber">
+    <posXYZ volume="VacuumChambDisk1" X_Y_Z="0.0 0.0 -25.30"/>
+    <posXYZ volume="VacuumChambDisk2" X_Y_Z="0.0 0.0  0.0"/>
+    <posXYZ volume="VacuumChambDisk3" X_Y_Z="0.0 0.0  25.30"/>
+  </composition>
+
+  <composition name="VacuumChambDisk1" envelope="VCO1">
+    <posXYZ volume="VCI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO1" Rio_Z="0.0  9.85   0.2" material="Iron" />
+  <tubs name="VCI1" Rio_Z="0.0  6.19   0.2" material="Vacuum" />
+
+  <composition name="VacuumChambDisk2" envelope="VCO2">
+    <posXYZ volume="VCI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO2" Rio_Z="0.0  9.85  50.40" material="Iron" />
+  <tubs name="VCI2" Rio_Z="0.0  9.83  50.40" material="Vacuum" />
+
+  <composition name="VacuumChambDisk3" envelope="VCO3">
+    <posXYZ volume="VCI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO3" Rio_Z="0.0  9.85  0.2" material="Iron" />
+  <tubs name="VCI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+
+<!-- Lead Band 1 -->
+
+  <composition name="LeadBand1" envelope="LBD1">
+    <posXYZ volume="LeadBandPipe1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe1" envelope="LBO1">
+    <posXYZ volume="LBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD1" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO1" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI1" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 3 -->
+
+  <composition name="Flange3">
+    <posXYZ volume="FlangeThreeDisk1" X_Y_Z="0.0  0.0  24.56" />
+    <posXYZ volume="FlangeThreeDisk2" X_Y_Z="0.0  0.0  50.70"/>
+    <posXYZ volume="FlangeThreeDisk3" X_Y_Z="0.0  0.0  55.78"/>
+    <posXYZ volume="FlangeThreeDisk4" X_Y_Z="0.0  0.0  60.86"/>
+    <posXYZ volume="FlangeThreeDisk5" X_Y_Z="0.0  0.0  64.99"/>
+  </composition>
+
+  <composition name="FlangeThreeDisk1" envelope="F3O1">
+    <posXYZ volume="F3I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O1" Rio_Z="0.0  2.54  49.12" material="Iron" />
+  <tubs name="F3I1" Rio_Z="0.0  2.38  49.12" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk2" envelope="F3O2">
+    <posXYZ volume="F3I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk3" envelope="F3O3">
+    <posXYZ volume="F3I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F3I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk4" envelope="F3O4">
+    <posXYZ volume="F3I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk5" envelope="F3O5">
+    <posXYZ volume="F3I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O5" Rio_Z="0.0  2.54   5.1" material="Iron" />
+  <tubs name="F3I5" Rio_Z="0.0  2.38   5.1" material="Vacuum" />
+
+
+<!-- 2nd Collimator -->
+
+  <composition name="COL2" envelope="OCOL">
+    <posXYZ volume="ICOL" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="OCOL" Rio_Z="0.0  10.0  50.8" material="Iron" />
+  <tubs name="ICOL" Rio_Z="0.0   0.5  50.8" material="Vacuum" />
+
+<!-- Flange 4 -->
+
+  <composition name="Flange4">
+    <posXYZ volume="FlangeFourDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFourDisk2" X_Y_Z="0.0  0.0  9.84"/>
+    <posXYZ volume="FlangeFourDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFourDisk4" X_Y_Z="0.0  0.0  20.0"/>
+    <posXYZ volume="FlangeFourDisk5" X_Y_Z="0.0  0.0  26.71"/>
+  </composition>
+
+  <composition name="FlangeFourDisk1" envelope="F4O1">
+    <posXYZ volume="F4I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F4I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+
+  <composition name="FlangeFourDisk2" envelope="F4O2">
+    <posXYZ volume="F4I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk3" envelope="F4O3">
+    <posXYZ volume="F4I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F4I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFourDisk4" envelope="F4O4">
+    <posXYZ volume="F4I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I4" Rio_Z="0.0  1.745  3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk5" envelope="F4O5">
+    <posXYZ volume="F4I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O5" Rio_Z="0.0  1.905   10.26" material="Iron" />
+  <tubs name="F4I5" Rio_Z="0.0  1.745   10.26" material="Vacuum" />
+
+
+<!-- 2nd Sweeping Magnet -->
+
+  <composition name="sweepMagnet2">
+    <posXYZ volume="Core" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Core" envelope="POL2">
+    <posXYZ volume="Aperture" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Aperture" envelope="GAP2">
+    <posXYZ volume="MagnetPipe2" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="POL2" X_Y_Z="42.0  20.8  36.0" material="Iron" />
+  <box name="GAP2" X_Y_Z="20.3   5.0  36.0" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <composition name="MagnetPipe2" envelope="MPO2">
+    <posXYZ volume="MPI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="MPO2" Rio_Z="0.0  1.905  36.0" material="Iron" />
+  <tubs name="MPI2" Rio_Z="0.0  1.745  36.0" material="Vacuum" />
+
+
+<!-- Flange 5 -->
+
+  <composition name="Flange5">
+    <posXYZ volume="FlangeFiveDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFiveDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeFiveDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFiveDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeFiveDisk5" X_Y_Z="0.0  0.0  29.71"/>
+  </composition>
+
+  <composition name="FlangeFiveDisk1" envelope="F5O1">
+    <posXYZ volume="F5I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O1" Rio_Z="0.0  1.905  8.26" material="Iron" />
+  <tubs name="F5I1" Rio_Z="0.0  1.745  8.26" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk2" envelope="F5O2">
+    <posXYZ volume="F5I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk3" envelope="F5O3">
+    <posXYZ volume="F5I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F5I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk4" envelope="F5O4">
+    <posXYZ volume="F5I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk5" envelope="F5O5">
+    <posXYZ volume="F5I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O5" Rio_Z="0.0  2.54  16.26" material="Iron" />
+  <tubs name="F5I5" Rio_Z="0.0  2.38  16.26" material="Vacuum" />
+
+
+<!-- Beam Pipe1 -->
+
+  <composition name="BeamPipe1" envelope="BPO1">
+    <posXYZ volume="BPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPO1" Rio_Z="0.0  2.54  52.32" material="Iron" />
+  <tubs name="BPI1" Rio_Z="0.0  2.38  52.32" material="Vacuum" />
+
+<!-- Lead Band 2 -->
+
+  <composition name="LeadBand2" envelope="LBD2">
+    <posXYZ volume="LeadBandPipe2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe2" envelope="LBO2">
+    <posXYZ volume="LBI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD2" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO2" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI2" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 6 -->
+
+<!-- Without DET2
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  25.71"/>
+  </composition>
+-->
+
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.08" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.74" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.82"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  19.9" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  35.98"/>
+  </composition>
+
+  <composition name="FlangeSixDisk1" envelope="F6O1">
+    <posXYZ volume="F6I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+<!-- Without DET2
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+-->
+
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.16" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk2" envelope="F6O2">
+    <posXYZ volume="F6I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk3" envelope="F6O3">
+    <posXYZ volume="F6I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F6I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSixDisk4" envelope="F6O4">
+    <posXYZ volume="F6I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk5" envelope="F6O5">
+    <posXYZ volume="F6I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O5" Rio_Z="0.0  2.54   29.0" material="Iron" />
+  <tubs name="F6I5" Rio_Z="0.0  2.38   29.0" material="Vacuum" />
+
+
+  <composition name="TargetBox">
+    <posXYZ volume="TargetBoxDisk1" X_Y_Z="0.0 0.0 -10.9"/>
+    <posXYZ volume="TargetBoxDisk2" X_Y_Z="0.0 0.0  0.0" />
+    <posXYZ volume="TargetBoxDisk3" X_Y_Z="0.0 0.0  10.9"/>
+  </composition>
+
+  <composition name="TargetBoxDisk1" envelope="TBO1">
+    <posXYZ volume="TBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO1" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI1" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+  <composition name="TargetBoxDisk2" envelope="TBO2">
+    <posXYZ volume="TargetInnerBox" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="TargetInnerBox" envelope="TBI2">
+    <posXYZ volume="CONV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO2" X_Y_Z="22.0  20.0  21.6" material="Iron" />
+  <box name="TBI2" X_Y_Z="21.6  19.6  21.6" material="Vacuum" />
+
+  <composition name="TargetBoxDisk3" envelope="TBO3">
+    <posXYZ volume="TBI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO3" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+  <box  name="CONV" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />
+
+
+
+
+
+
+<!-- Flange 7 -->
+
+  <composition name="Flange7">
+    <posXYZ volume="FlangeSevenDisk1" X_Y_Z="0.0  0.0  8.8721" />
+    <posXYZ volume="FlangeSevenDisk2" X_Y_Z="0.0  0.0  19.3224" />
+    <posXYZ volume="FlangeSevenDisk3" X_Y_Z="0.0  0.0  24.4024" />
+    <posXYZ volume="FlangeSevenDisk4" X_Y_Z="0.0  0.0  29.4824" />
+    <posXYZ volume="FlangeSevenDisk5" X_Y_Z="0.0  0.0  35.1924" />
+  </composition>
+
+  <composition name="FlangeSevenDisk1" envelope="F7O1">
+    <posXYZ volume="F7I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O1" Rio_Z="0.0  2.54  17.7424" material="Iron" />
+  <tubs name="F7I1" Rio_Z="0.0  2.38  17.7424" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk2" envelope="F7O2">
+    <posXYZ volume="F7I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk3" envelope="F7O3">
+    <posXYZ volume="F7I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F7I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk4" envelope="F7O4">
+    <posXYZ volume="F7I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk5" envelope="F7O5">
+    <posXYZ volume="F7I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O5" Rio_Z="0.0  2.54   8.26" material="Iron" />
+  <tubs name="F7I5" Rio_Z="0.0  2.38   8.26" material="Vacuum" />
+
+
+<!-- Concrete Wall -->
+
+  <composition name="ConcreteWall2" envelope="BLC2">
+    <posXYZ volume="ENTR" X_Y_Z="-179.0  0.0 -30.46"/>
+    <posXYZ volume="Block2Hole" X_Y_Z="0.0 -33.0 0.0"/>
+  </composition>
+
+  <box name="ENTR" X_Y_Z="92.0 266.0 61.0" material="Air" />
+
+  <composition name="Block2Hole" envelope="OBHO">
+    <posXYZ volume="IBHO"  X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="BLC2" X_Y_Z="450.0 266.0 121.92" material="Concrete" />
+  <tubs name="OBHO" Rio_Z="0.0  2.54  121.92" material="Iron" />
+  <tubs name="IBHO" Rio_Z="0.0  2.38  121.92" material="Vacuum" />
+
+
+<!-- Lead Wall -->
+
+  <composition name="shieldingWall" envelope="WALL">
+    <posXYZ volume="WallHole" X_Y_Z="0.0  -35.0  0.0"/>
+  </composition>
+
+  <box name="WALL" X_Y_Z="450. 270. 5.08" material="Lead" />
+
+  <composition name="WallHole" envelope="OWHO">
+    <posXYZ volume="IWHO" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="OWHO" Rio_Z="0.0  2.54 5.08" material="Iron" />
+  <tubs name="IWHO" Rio_Z="0.0  2.38 5.08" material="Vacuum" />
+
+
+<!-- Beam Pipe2 -->
+
+  <composition name="BeamPipe2" envelope="BPO2">
+  <!-- MUST COMMENT OUt either one or the other of the two lines below -->
+    <!-- <posXYZ volume="BeamPipe2Inner" /> enables the photon beam harp -->
+    <posXYZ volume="BPI2" /> <!-- disables the photon beam harp -->
+  </composition>
+  
+  <composition name="BeamPipe2Inner" envelope="BPI2">
+    <posXYZ volume="photonBeamHarp" X_Y_Z="0.0 0.0 -27.38" />
+  </composition>
+  
+  <composition name="photonBeamHarp">
+    <posXYZ volume="PSCV" />
+    <posXYZ volume="PSCH" />
+  </composition>
+
+  <tubs name="BPO2" Rio_Z="0.0  2.54   118.767" material="Iron" />
+  <tubs name="BPI2" Rio_Z="0.0  2.38   118.767" material="Vacuum" />
+    
+  <composition name="PairSpecConverter" envelope="PSCM">
+    <posXYZ volume="PSCV"/>
+    <posXYZ volume="PSCH"/>
+  </composition>
+  
+  <tubs name="PSCM" Rio_Z="0.0 2.38 0.53" material="Vacuum"/>
+  <tubs name="PSCV" Rio_Z="0.0 1.143 0.01" material="Aluminum"/>
+  <tubs name="PSCH" Rio_Z="1.143 2.38 0.53" material="Iron"/>
+
+  <tubs name="DET1" Rio_Z="0.   50.  2." material="Air" />
+  <box name="DET2" X_Y_Z=" 450. 270. 0.1" material="Vacuum" />
+  <box name="DET3" X_Y_Z=" 450. 2. 918." material="Air" />
+
+  
+<!-- The composition 'beamPipe' extends the vacuum from the pair 
+     spectrometer to the position of the target.
+
+     Origin of beamPipe is center of the hall.
+-->
+
+  <composition name="beamPipe">
+<!--    <posXYZ volume="DET4"     X_Y_Z="  0.0     0.0 -1400.0"/> -->
+    <posXYZ volume="DET5"     X_Y_Z="  0.0     0.0  1400.0"/> 
+    <posXYZ volume="TAC1" X_Y_Z="150.0  -350.0  1225.0" />  
+    <posXYZ volume="DarkWindow" X_Y_Z="  150.0  -350.0  320.0" />
+    <posXYZ volume="PlatformPipe" X_Y_Z="150.0  -350.0  650."/>
+    <posXYZ volume="PlexWindow" X_Y_Z="150.0  -350.0  830."/>
+    <posXYZ volume="IntMonitor" X_Y_Z="150.0  -350.0  834."/>
+    <posXYZ volume="DET6"     X_Y_Z="  0.0   600.0     0.0"/>
+    <!--posXYZ volume="DET7"     X_Y_Z="  0.0     0.0  -705.0"/--> 
+    <posXYZ volume="HallBellows" X_Y_Z="150.0 -350.0 -1223.287"/>
+    <posXYZ volume="HallPipe" X_Y_Z="150.0  -350.0  -1026.77"/>
+    <!-- Plastic scintillator for beam diagonistics -->
+    <!--posXYZ volume="DET8" X_Y_Z="150 -350.0 -834.0 "/-->
+  </composition>
+
+  <composition name="DarkWindow">
+    <posXYZ volume="DBOW" X_Y_Z="  0.0  0.0  0.0" />
+    <posXYZ volume="DBEW" X_Y_Z="  0.0  0.0  0.0" />
+  </composition>
+
+  <tubs name="DBOW" Rio_Z="20.0  60.0  0.3"  material="Aluminum"/>
+  <tubs name="DBEW" Rio_Z="0.0   20.0  0.01" material="Tedlar"/>
+
+  <composition name="PlatformPipe">
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0  -176.5127" />
+    <posXYZ volume="PipeSection" X_Y_Z="0.0 0.0 0.0" />
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0   176.5127" />
+  </composition>
+
+  <tubs name="PPWD" Rio_Z="0.0   20.32  0.0254" material="Kapton" />
+
+  <composition name="PipeSection" envelope="PPOV">
+    <posXYZ volume="PPIV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PPOV" Rio_Z="0.0   20.32  353.0" material="Iron" />
+  <tubs name="PPIV" Rio_Z="0.0   20.04  353.0" material="Vacuum" />
+
+  <composition name="PlexWindow">
+    <posXYZ volume="PPPW" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="IntMonitor" >
+    <posXYZ volume="INTM" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box  name="INTM" X_Y_Z="2  6  1" material="Scintillator"  />
+
+  <tubs name="PPPW" Rio_Z="0.0   20.32  0.3" material="Plexiglas" />
+
+  <box  name="TAC1" X_Y_Z="20  20  45" material="leadGlassF800" sensitive="true" />
+
+
+  <box name="DET4" X_Y_Z="1700.0  1200.0  2.0" material="Vacuum" />
+  <box name="DET5" X_Y_Z="1700.0  1198.0  2.0" material="Air" />
+  <box name="DET6" X_Y_Z="1700.0  2.0  3000.0" material="Air" />
+  <!--box name="DET7" X_Y_Z="1700.0  1198.0  2.0" material="Air" /-->
+  <tubs name="DET7" Rio_Z="0.0 1.7399  2.0" material="Vacuum"
+        comment="disk detector inside beam pipe at target entrance" />
+  <box name="DET8" X_Y_Z="10.0 10.0 1.0" material="Scintillator" sensitive="true"/>
+
+<!-- Hall bellows -->
+<composition name="HallBellows" envelope="BLWO">
+  <posXYZ volume="BLWI" X_Y_Z="0.0 0.0 -3.5011"/>
+</composition>
+
+<pcon name="BLWO" material="Iron">
+  <polyplane Rio_Z="0.0 1.90500 -13.4"/>
+  <polyplane Rio_Z="0.0 1.90500 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 6.3978"/>
+</pcon>
+
+<tubs name="BLWI" Rio_Z="0. 1.7399 19.7978" material="Vacuum"/>
+
+<!-- Hall Pipe -->
+  <composition name="HallPipe" envelope="OHPI" >
+    <!--posXYZ volume="IHPI" X_Y_Z="0 0 98.6305"/-->
+    <posXYZ volume="InnerHallPipe" X_Y_Z="0.0 0.0 98.6305"/> 
+  </composition>
+
+  <composition name="InnerHallPipe" envelope="IHPI">
+    <posXYZ volume="DET7" X_Y_Z="0 0 280.0"/> 
+    <!--posXYZ volume="CAP1" X_Y_Z="0.0  0.0  190.11265" /-->
+  </composition>
+
+
+  <pcon name="OHPI" material="Iron">
+    <polyplane Rio_Z="0.0 4.27355 -190.1190"/>
+    <polyplane Rio_Z="0.0 4.27355 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +387.380"/>
+  </pcon>
+
+  <tubs name="IHPI" Rio_Z="0.0  1.7399 577.499" material="Vacuum" />
+  <tubs name="CAP1" Rio_Z="0.0  1.7399 0.0127" material="Kapton"/>
+
+<composition name="SixWayCross" envelope="SWCM">
+  <posXYZ volume="sixWayTube" X_Y_Z="0 0 0"/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0 0." rot="0. 180. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 90. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 270. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="90. 0. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="270. 0. 0."/>
+  <posXYZ volume="sixWayBox" X_Y_Z="0. 0. 0."/> 
+</composition>
+
+<box name="SWCM" X_Y_Z="67.9196 67.9196 67.9196" material="Air"
+     comment="Six-way cross mother volume"/>
+<pcon name="SWCP" material="StainlessSteel" comment="Vacuum pipe for 6-way cross">
+  <polyplane Rio_Z="0. 20.32 20.32"/>
+  <polyplane Rio_Z="0. 20.32 32.258"/>
+  <polyplane Rio_Z="0. 22.504 32.258"/>
+  <polyplane Rio_Z="0. 22.504 33.9598"/>
+</pcon>
+  
+<composition name="sixWayTube" envelope="SWCP">
+  <posXYZ volume="SWC2" X_Y_Z="0.0 0.0 27.1399"/>
+</composition>
+
+<composition name="sixWayBox" envelope="SWCB">
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 -20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 -20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="20.08125 0. 0." rot="0 90 0 "/>
+  <posXYZ volume="SWC1" X_Y_Z="-20.08125 0. 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeMotherVolume" X_Y_Z="0. 0. 0." />
+</composition>
+
+<composition name="coldCubeMotherVolume" envelope="CBXM">
+  <posXYZ volume="CBX1" X_Y_Z="0. -7.712  0."/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.1444"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.3032"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 -12.1444"/>
+  <posXYZ volume="CBXS" X_Y_Z="12.1444 4.28 0."/>
+  <posXYZ volume="CBXS" X_Y_Z="-12.1444 4.28 0."/>
+  <posXYZ volume="coldCubeTopPlate" X_Y_Z="0. 16.272 0." rot="90 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 -11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="11.9856 4.28 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="-11.9856 4.28 0." rot="0 90 0"/>
+</composition>
+
+<composition name="coldCubeBeamPlate" envelope="CBXB">
+  <posXYZ volume="CBH0" X_Y_Z="0. -4.2926 0."/>
+</composition>
+
+<composition name="coldCubeSidePlate" envelope="CBSP">
+  <posXYZ volume="CBH2" X_Y_Z="0. 0. 0."/>
+</composition>
+
+<composition name="coldCubeTopPlate" envelope="CHXT">
+  <posXYZ volume="CBH1" X_Y_Z="0. 0. 0." />
+</composition>
+
+<box name="CBSP" X_Y_Z="23.8124 23.8124 0.15875" material="Copper"/>
+<box name="CHXT" X_Y_Z="24.13 24.13 0.15875" material="Copper"/>
+<tubs name="CBH1" Rio_Z="0. 10.795 0.15875" material="Vacuum"/>
+<tubs name="CBH0" Rio_Z="0 1.27 0.15875" material="Vacuum" 
+      comment="Hole for beam"/>
+<box name="CBH2" X_Y_Z="19.05 19.05 0.15875" material="Vacuum"/>
+<box name="CBXB" X_Y_Z="21.8948 21.8948 0.15875" material="Copper"/>
+<box name="CBXS" X_Y_Z="0.15875 21.8948 21.8948" material="Copper"/>
+<box name="CBX1" X_Y_Z="24.13 0.15875 24.13" material="Copper"/>
+<box name="CBXM" X_Y_Z="39.685 39.685 39.685" material="Vacuum"/>
+<box name="SWCB" X_Y_Z="40.64 40.64 40.64" material="StainlessSteel"/>
+<tubs name="SWC1" Rio_Z="0 19.84248 0.4775" material="Vacuum"/>
+<tubs name="SWC2" Rio_Z="0. 19.84248 13.6398" material="Vacuum"/>
+
+<!-- Approximation for the beam profiler -->
+<box name="PFSC" X_Y_Z="12.8 12.8 0.2" material="Scintillator" sensitive="true"/>
+<box name="PFLD" X_Y_Z="10.0 10.0 0.1" material="Lead"/>
+
+<!-- Following is the definition of the active collimator.  It sits
+     on the upstream end of the primary collimator and acts as an
+     active absorber with segmented detection of the beam intensity.
+-->
+
+  <composition name="ColDetector" envelope="INSU">
+    <posXYZ volume="ColAssemblyFinal" X_Y_Z="0.0 0.0 0.50"/>
+    <posXYZ volume="HOUF" X_Y_Z="0.0  0.0  -1.85"/>
+  </composition>
+
+  <composition name="ColAssemblyFinal" envelope="HOUS">
+    <posXYZ volume="ColAssemblyInitial" X_Y_Z="0.0  0.0  -0.15"/>
+  </composition>
+  
+  <composition name="ColAssemblyInitial" envelope="AIRH">
+    <mposPhi volume="DIV1" ncopy="4" Phi0="0" dPhi="90" R_Z="3.375 0."/>  
+    <mposPhi volume="DIV2" ncopy="4" Phi0="45" dPhi="90"/>  
+    <mposPhi volume="innerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+    <mposPhi volume="outerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+  </composition>
+
+  <tubs name="INSU" Rio_Z="0.25   7.36  4.20" material="BoronNitride"/>
+ 
+  <tubs name="HOUS" Rio_Z="0.25   6.70  3.20" material="Aluminum" />
+ 
+  <tubs name="HOUF" Rio_Z="0.25   6.85  0.50" material="Aluminum"/>
+ 
+  <tubs name="AIRH" Rio_Z="0.25   6.5002  2.9" material="Air" />
+  <box  name="DIV1" X_Y_Z="6.25  0.1  2.9" material="Aluminum" />
+  <tubs name="DIV2" Rio_Z="2.7   2.8  2.9" profile="-42.870 85.740"
+                                           material="Aluminum" />
+
+  <composition name="innerPinCushionWedge" envelope="ACWI">
+    <posXYZ volume="ACBI" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="innerPinCushionRow_1" X_Y_Z="0.276 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_2" X_Y_Z="0.376 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_3" X_Y_Z="0.476 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_4" X_Y_Z="0.576 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_5" X_Y_Z="0.676 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_6" X_Y_Z="0.776 0.0 0.40" />
+  </composition>
+  <composition name="innerPinCushionRow_1" envelope="AIR1">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_2" envelope="AIR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_3" envelope="AIR3">
+    <mposY volume="PIN1" ncopy="5" Y0="-0.20" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_4" envelope="AIR4">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_5" envelope="AIR5">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_6" envelope="AIR6">
+    <mposY volume="PIN1" ncopy="9" Y0="-0.40" dY="0.10" />
+  </composition>
+
+  <composition name="outerPinCushionWedge" envelope="ACWO">
+    <posXYZ volume="ACBO" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 -1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 +1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 -1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 +1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 -1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 +1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 -1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 +1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_5" X_Y_Z="3.025 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_6" X_Y_Z="3.125 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_7" X_Y_Z="3.225 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_8" X_Y_Z="3.325 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_9" X_Y_Z="3.425 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_10" X_Y_Z="3.525 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_11" X_Y_Z="3.625 0.0 0.40" />
+  </composition>
+  <composition name="outerPinCushionRow_1" envelope="AOR1">
+    <posXYZ volume="PIN1" />
+  </composition>
+  <composition name="outerPinCushionRow_2" envelope="AOR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_3" envelope="AOR3">
+    <mposY volume="PIN1" ncopy="6" Y0="-0.25" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_4" envelope="AOR4">
+    <mposY volume="PIN1" ncopy="10" Y0="-0.45" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_5" envelope="AOR5">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_6" envelope="AOR6">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_7" envelope="AOR7">
+    <mposY volume="PIN1" ncopy="37" Y0="-1.80" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_8" envelope="AOR8">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_9" envelope="AOR9">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_10" envelope="AORA">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_11" envelope="AORB">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+
+  <tubs name="ACWI" Rio_Z="0.25 2.5  2.5" profile="-33. 66."
+         material="Air" comment="active collimator inner wedge" />  
+  <tubs name="ACWO" Rio_Z="2.97  6.0  2.5" profile="-33. 66."
+         material="Air" comment="active collimator outer wedge" />  
+  <tubs name="ACBI" Rio_Z="0.25 2.5  0.8" profile="-32. 64."
+         material="SoftTungsten" comment="inner wedge base plate" />  
+  <tubs name="ACBO" Rio_Z="3.0  6.0  0.8" profile="-30. 60."
+         material="SoftTungsten" comment="outer wedge base plate" />  
+
+  <box name="AIR1" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AIR2" X_Y_Z="0.051 0.40 1.7" material="Air" />
+  <box name="AIR3" X_Y_Z="0.051 0.50 1.7" material="Air" />
+  <box name="AIR4" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AIR5" X_Y_Z="0.051 0.80 1.7" material="Air" />
+  <box name="AIR6" X_Y_Z="0.051 0.90 1.7" material="Air" />
+
+  <box name="AOR1" X_Y_Z="0.051 0.10 1.7" material="Air" />
+  <box name="AOR2" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AOR3" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AOR4" X_Y_Z="0.051 1.00 1.7" material="Air" />
+  <box name="AOR5" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR6" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR7" X_Y_Z="0.051 3.70 1.7" material="Air" />
+  <box name="AOR8" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AOR9" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AORA" X_Y_Z="0.051 4.10 1.7" material="Air" />
+  <box name="AORB" X_Y_Z="0.051 4.10 1.7" material="Air" />
+
+  <box name="PIN1" X_Y_Z="0.051 0.051 1.7" material="SoftTungsten" />
+ 
+<!-- Following is the definition of the triplet polarimeter.  It sits
+     just before of the shielding wall at the downstream end of the
+     collimator cave, and contains a retractable pair conversion target
+     called PTAR. Forward pairs are detected in the pair spectrometer.
+-->
+
+<!-- Origin of TripletPolar is the beam axis midpoint
+     of the polarimeter vacuum box, as set by the outside walls. -->
+
+  <composition name="TripletPolar">
+     <apply region="nullBfield"/>
+     <posXYZ volume="tripletPolar" X_Y_Z="1.5 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tripletPolar">
+     <posXYZ volume="tpolEnclosure" />
+     <posXYZ volume="tpolVacuumBoxFlange" X_Y_Z="6.50 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTPT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTPM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTIT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTIM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFT" X_Y_Z="0.0 -7.91 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTFM" X_Y_Z="-4.0 4.0 +7.91" unit_length="in" />
+     <posXYZ volume="PTFF" X_Y_Z="-6.910 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 -8.5" unit_length="in" />
+     <posXYZ volume="PTKM" X_Y_Z="-4.0 4.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKF" X_Y_Z="-7.550 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTDR" X_Y_Z="7.25 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tpolVacuumBox" envelope="PTB0">
+     <posXYZ volume="tpolRailGuide" X_Y_Z="0.375 5.131 -3.380" unit_length="in" />
+     <posXYZ volume="tpolTargetCarrier" X_Y_Z="0.25 2.146 -3.380" rot="0 180 0" unit_length="in" />
+     <posXYZ volume="tpolTargetMotor" X_Y_Z="-1.625 4.1449 -1.6284" unit_length="in" />
+     <posXYZ volume="tpolRecoilDetectorCard" X_Y_Z="-1.625 0.0 -2.0" rot="0 0 22.5" unit_length="in" />
+     <posXYZ volume="PTA1" X_Y_Z="-1.625 0.0 -1.9796" unit_length="in" />
+     <posXYZ volume="PTA2" X_Y_Z="-1.625 0.0 -1.9795" unit_length="in" />
+     <posXYZ volume="PTA3" X_Y_Z="-1.625 0.0 -1.9794" unit_length="in" />
+     <posXYZ volume="PTA4" X_Y_Z="-1.625 0.0 -2.0204" unit_length="in" />
+     <!-- <posXYZ volume="PTA5" X_Y_Z="-1.625 0.0 -3.3651" unit_length="in" /> -->
+     <posXYZ volume="PTMP" X_Y_Z="0.0 5.8125 0.0" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 -5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 -4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="-5.125 5.745 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="-4.625 5.5525 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 -2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="0.4872 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="-3.7372 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="0.4872 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="-3.7372 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="0.4872 5.5 -0.6216" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="-3.7372 5.5 -0.6216" unit_length="in" />
+  </composition>
+
+  <composition name="tpolEnclosure" envelope="PTBO">
+     <posXYZ volume="tpolVacuumBox" X_Y_Z="0.125 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH3" X_Y_Z="-4.0 4.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH6" X_Y_Z="0.0 -6.125 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH5" X_Y_Z="-6.125 0.0 -2.0" rot="0 90 0" unit_length="in" />
+  </composition>
+
+  
+  <tubs name="PTAR" Rio_Z="0.0 0.375 0.0075" material="Vacuum" 
+	comment="polarimeter converter target" /> 
+  
+  
+  <box name="PTBO" X_Y_Z="12.5 12.5 12.5" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube1" />
+  <box name="PTB0" X_Y_Z="12.25 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube2" />
+  <box name="PTB1" X_Y_Z="0.5 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box flange subtraction" />
+  <box name="PTB2" X_Y_Z="0.5 15.0 17.0" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box door flange" />
+  <box name="PTB3" X_Y_Z="9.25 0.988 0.625" material="Aluminum" unit_length="in"
+                   comment="polarimeter rail guide" />
+  <box name="PTB4" X_Y_Z="9.25 0.312 0.125" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail gap subtraction" />
+  <box name="PTB5" X_Y_Z="9.25 0.365 0.375" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail box subtraction" />
+  <box name="PTB6" X_Y_Z="42.0 42.0 2.0" material="Iron" unit_length="mm"
+                   comment="polarimeter motor plate" />
+  <box name="PTB7" X_Y_Z="5.25 5.792 0.118" material="Aluminum" unit_length="in"
+                   comment="polarimeter target holder" />
+  <box name="PTB8" X_Y_Z="4.325 4.292 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter target holder subtraction" />
+  <tubs name="PTH0" Rio_Z="0.0 21.0 69.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motor" />
+  <tubs name="PTH1" Rio_Z="0.0 10.5 32.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motion gear" />
+  <tubs name="PTH2" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter beam hole subtraction" />
+  <tubs name="PTH3" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter motor hole subtraction" />
+  <tubs name="PTH4" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter auxilliary hole subtraction" />
+  <tubs name="PTH5" Rio_Z="0.0 1.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter feed hole subtraction" />
+  <tubs name="PTH6" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter turbo pump hole subtraction" />
+  <tubs name="PTH7" Rio_Z="0.0 0.375 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter converter tray subtraction" />
+
+  <composition name="tpolVacuumBoxFlange" envelope="PTB2">
+     <posXYZ volume="PTB1" />
+  </composition>
+  <composition name="tpolRailGuide" envelope="PTB3">
+     <posXYZ volume="PTB4" X_Y_Z="0.0 -0.338 0.0" unit_length="in" />
+     <posXYZ volume="PTB5" />
+  </composition>
+  <composition name="tpolTargetDisk" envelope="PTH7">
+     <posXYZ volume="PTAR" />
+  </composition>
+  <composition name="tpolTargetCarrier" envelope="PTB7">
+     <posXYZ volume="PTB8" X_Y_Z="0.4625 0.75 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="1.875 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="0.625 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="-0.625 -2.146 0.0" unit_length="in" />
+  </composition>
+  <composition name="tpolTargetMotor">
+     <posXYZ volume="PTH0" />
+     <posXYZ volume="PTB6" X_Y_Z="0.0 0.0 -35.5" unit_length="mm" />
+     <posXYZ volume="PTH1" X_Y_Z="0.0 0.0 -52.5" unit_length="mm" />
+  </composition>
+  
+  <composition name="tpolRecoilDetector" envelope="PTDE">
+     <posXYZ volume="tpolRecoilRing1" />
+     <posXYZ volume="tpolRecoilRing2" />
+     <posXYZ volume="tpolRecoilRing3" />
+     <posXYZ volume="tpolRecoilRing4" />
+     <posXYZ volume="tpolRecoilRing5" />
+     <posXYZ volume="tpolRecoilRing6" />
+     <posXYZ volume="tpolRecoilRing7" />
+     <posXYZ volume="tpolRecoilRing8" />
+     <posXYZ volume="tpolRecoilRing9" />
+     <posXYZ volume="tpolRecoilRing10" />
+     <posXYZ volume="tpolRecoilRing11" />
+     <posXYZ volume="tpolRecoilRing12" />
+     <posXYZ volume="tpolRecoilRing13" />
+     <posXYZ volume="tpolRecoilRing14" />
+     <posXYZ volume="tpolRecoilRing15" />
+     <posXYZ volume="tpolRecoilRing16" />
+     <posXYZ volume="tpolRecoilRing17" />
+     <posXYZ volume="tpolRecoilRing18" />
+     <posXYZ volume="tpolRecoilRing19" />
+     <posXYZ volume="tpolRecoilRing20" />
+     <posXYZ volume="tpolRecoilRing21" />
+     <posXYZ volume="tpolRecoilRing22" />
+     <posXYZ volume="tpolRecoilRing23" />
+     <posXYZ volume="tpolRecoilRing24" />
+  </composition>
+  <tubs name="PTDE" Rio_Z="11.0 35.0 1.5" material="Vacuum" unit_length="mm" 
+                   comment="container for the triplet polarimeter detector" />
+
+  <composition name="tpolRecoilRing1" envelope="PTRA">
+     <mposPhi volume="PTSA" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="1" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing2" envelope="PTRB">
+     <mposPhi volume="PTSB" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="2" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing3" envelope="PTRC">
+     <mposPhi volume="PTSC" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="3" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing4" envelope="PTRD">
+     <mposPhi volume="PTSD" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="4" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing5" envelope="PTRE">
+     <mposPhi volume="PTSE" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="5" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing6" envelope="PTRF">
+     <mposPhi volume="PTSF" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="6" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing7" envelope="PTRG">
+     <mposPhi volume="PTSG" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="7" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing8" envelope="PTRH">
+     <mposPhi volume="PTSH" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="8" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing9" envelope="PTRI">
+     <mposPhi volume="PTSI" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="9" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing10" envelope="PTRJ">
+     <mposPhi volume="PTSJ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="10" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing11" envelope="PTRK">
+     <mposPhi volume="PTSK" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="11" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing12" envelope="PTRL">
+     <mposPhi volume="PTSL" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="12" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing13" envelope="PTRM">
+     <mposPhi volume="PTSM" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="13" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing14" envelope="PTRN">
+     <mposPhi volume="PTSN" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="14" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing15" envelope="PTRO">
+     <mposPhi volume="PTSO" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="15" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing16" envelope="PTRP">
+     <mposPhi volume="PTSP" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="16" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing17" envelope="PTRQ">
+     <mposPhi volume="PTSQ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="17" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing18" envelope="PTRR">
+     <mposPhi volume="PTSR" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="18" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing19" envelope="PTRS">
+     <mposPhi volume="PTSS" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="19" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing20" envelope="PTRT">
+     <mposPhi volume="PTST" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="20" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing21" envelope="PTRU">
+     <mposPhi volume="PTSU" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="21" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing22" envelope="PTRV">
+     <mposPhi volume="PTSV" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="22" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing23" envelope="PTRW">
+     <mposPhi volume="PTSW" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="23" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing24" envelope="PTRX">
+     <mposPhi volume="PTSX" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="24" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+
+  <tubs name="PTRA" Rio_Z="11 12 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRB" Rio_Z="12 13 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRC" Rio_Z="13 14 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRD" Rio_Z="14 15 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRE" Rio_Z="15 16 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRF" Rio_Z="16 17 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRG" Rio_Z="17 18 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRH" Rio_Z="18 19 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRI" Rio_Z="19 20 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRJ" Rio_Z="20 21 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRK" Rio_Z="21 22 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRL" Rio_Z="22 23 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRM" Rio_Z="23 24 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRN" Rio_Z="24 25 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRO" Rio_Z="25 26 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRP" Rio_Z="26 27 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRQ" Rio_Z="27 28 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRR" Rio_Z="28 29 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRS" Rio_Z="29 30 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRT" Rio_Z="30 31 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRU" Rio_Z="31 32 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRV" Rio_Z="32 33 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRW" Rio_Z="33 34 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRX" Rio_Z="34 35 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTSA" Rio_Z="11 12 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSB" Rio_Z="12 13 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSC" Rio_Z="13 14 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSD" Rio_Z="14 15 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSE" Rio_Z="15 16 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSF" Rio_Z="16 17 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSG" Rio_Z="17 18 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSH" Rio_Z="18 19 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSI" Rio_Z="19 20 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSJ" Rio_Z="20 21 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSK" Rio_Z="21 22 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSL" Rio_Z="22 23 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSM" Rio_Z="23 24 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSN" Rio_Z="24 25 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSO" Rio_Z="25 26 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSP" Rio_Z="26 27 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSQ" Rio_Z="27 28 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSR" Rio_Z="28 29 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSS" Rio_Z="29 30 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTST" Rio_Z="30 31 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSU" Rio_Z="31 32 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSV" Rio_Z="32 33 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSW" Rio_Z="33 34 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSX" Rio_Z="34 35 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+
+  <tubs name="PTA1" Rio_Z="11 35 0.0006" material="Aluminum" unit_length="mm"
+                    comment="called blank1, whatever that is" />
+  <tubs name="PTA2" Rio_Z="11 35 0.0035" material="Silicon" unit_length="mm" 
+                    comment="called blank2, whatever that is" />
+  <tubs name="PTA3" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank3, whatever that is" />
+  <tubs name="PTA4" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank4, whatever that is" />
+  <tubs name="PTA5" Rio_Z="0.0 9.525 0.5" material="Vacuum" unit_length="mm"
+                    comment="called blank5, whatever that is" />
+
+  <composition name="tpolRecoilDetectorCard" envelope="PTCA">
+     <posXYZ volume="tpolRecoilDetector" />
+     <posXYZ volume="PTCH" />
+  </composition>
+
+  <pgon name="PTCA" segments="8" material="FR-4" unit_length="mm"
+                   comment="card that carries the recoil polarimeter detector">
+     <polyplane Rio_Z="0 60 -0.75" unit_length="mm" />
+     <polyplane Rio_Z="0 60 0.75" unit_length="mm" />
+  </pgon>
+  <tubs name="PTCH" Rio_Z="0.0 11.0 1.5" material="Vacuum" unit_length="mm"
+                   comment="central hole through the polarimeter card" />
+  
+  <tubs name="PTPB" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="beam pipe to the upstream/downstream" />
+  <tubs name="PTIB" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="beam vacuum to the upstream/downstream" />
+  <tubs name="PTPF" Rio_Z="1.9375 2.0 1.05" material="Iron" unit_length="in"
+                   comment="feed pipe to the side" />
+  <tubs name="PTIF" Rio_Z="0.0 1.9375 1.05" material="Vacuum" unit_length="in"
+                   comment="feed vacuum to the side" />
+  <tubs name="PTPT" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe" />
+  <tubs name="PTIT" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="turbo pump port vacuum" />
+  <tubs name="PTPM" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="motor port pipe" />
+  <tubs name="PTIM" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="motor port vacuum" />
+  <tubs name="PTPX" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="aux port pipe" />
+  <tubs name="PTIX" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="aux port vacuum" />
+  <tubs name="PTFB" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="beam pipe flange to the upstream/downstream" />
+  <tubs name="PTFX" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="aux port pipe flange" />
+  <tubs name="PTFT" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe flange" />
+  <tubs name="PTFM" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="motor port pipe flange" />
+  <tubs name="PTFF" Rio_Z="2.0 3.0 0.78" material="Iron" unit_length="in"
+                   comment="feed pipe flange" />
+  <tubs name="PTKX" Rio_Z="0.0 1.6875 0.5" material="Iron" unit_length="in"
+                   comment="aux port pipe cap" />
+  <tubs name="PTKM" Rio_Z="0.0 2.250 0.5" material="Iron" unit_length="in"
+                   comment="motor port pipe cap" />
+  <tubs name="PTKF" Rio_Z="0.0 3.0 0.5" material="Iron" unit_length="in"
+                   comment="feed pipe cap" />
+
+  <box name="PTMP" X_Y_Z="10.0 0.375 10.0" material="Aluminum" unit_length="in"
+                   comment="mounting plate" />
+  <box name="PTVR" X_Y_Z="6.0 0.51 0.25" material="Iron" unit_length="in"
+                   comment="vertical rack piece" />
+  <box name="PTHR" X_Y_Z="6.0 0.125 0.75" material="Iron" unit_length="in"
+                   comment="horizontal rack piece" />
+  <box name="PTBR" X_Y_Z="4.75 0.50 0.0625" material="Aluminum" unit_length="in"
+                   comment="horizontal bar piece" />
+  <box name="PTLG" X_Y_Z="0.5 7.987 0.125" material="Aluminum" unit_length="in"
+                   comment="support leg" />
+  <box name="PTVS" X_Y_Z="0.5 2.5 0.25" material="Aluminum" unit_length="in"
+                   comment="vertical support piece" />
+  <box name="PTHS" X_Y_Z="0.5 0.25 2.5" material="Aluminum" unit_length="in"
+                   comment="horizontal support piece" />
+  <box name="PTDR" X_Y_Z="1.0 15.0 17.0" material="Aluminum" unit_length="in"
+                   comment="vacuum box door" />
+
+  <!-- there is no mcfast model of the photon beamline -->
+
+</section>
+
+<!-- </HDDS> -->

--- a/BeamLine_HDDS_34_0.xml
+++ b/BeamLine_HDDS_34_0.xml
@@ -1,0 +1,1642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DOCTYPE HDDS>
+
+  Hall D Geometry Data Base: Beam Line
+  ************************************
+
+     version 1.0: Initial version	-rtj
+
+     Revision 1.1 10/18/2002 
+     -added concrete shielding to the collimator housing 
+     -added the virtual detectors to this code:
+        DET1: disk intercepting entire beam upstream of collimators
+        DET2: plane perpendicular to beam just after second collimator
+        DET3: plane mounted just below the ceiling of collimator cave
+        DET4: plane perpendicular to beam just after entry to hall
+        DET5: plane perpendicular to beam at photon dump end of hall
+        DET6: plane mounted just below the ceiling inside the hall
+        DET7: plane perpendicular to beam just before the target
+     -added a steel tube containing a vacuum that goes from the back of
+      the collimator to the front of the solenoid  
+     -csg-
+
+     Revision 1.2 10/28/2002
+     -revised collimator to the heavy shielding option 
+     -added a steel tube containing a vacuum in the WALL, SHLD and ABS2 volumes
+     -repositioned DET3 to be inside the collimator housing 
+     -removed the BEAM volume from the collimator system
+     -csg-
+
+     Revision 1.3 1/9/2003
+     -shrunk the size of the vacuum tube from r=5.3 to r=2.5 in order to
+      extend the tube into the second steering magnet
+     -csg-
+
+     Revision 1.4 06/16/2003
+     -mid-shielding option
+     -modified DET1, now a cylinder placed in front of primary collimator
+     -added tungsten pin-cushion detector model into simulation
+     -csg- 
+
+     Revision 2.0 05/16/2008
+     -moved DET2 to just after the second collimator, in agreement with
+      the comments below.  Somehow it got misplaced to upstream of the
+      second collimator.  I guess no one was using it until now.
+     -added the volume CONV for the pair conversion target located inside
+      the vacuum pipe just downstream of the second sweep magnet.  Right
+      now it its material is vacuum, but the thickness of 240 microns is
+      chosen to make a 0.1% converter if the material is set to Carbon.
+
+
+     Revision 2.1  12/12/2008, A.S., rtj
+       Made the following changes in the composition 'collimatorStack':
+  	  1. Added the composition BeamPipe0 describing a vacuum beam pipe at the entrance 
+             of the collimator cave:
+              - the beam pipe radius is 12.4 cm
+              - the exit window: 250 micron Kapton with the radius of 10.14 cm. 
+ 	  2. Moved the active collimator, DET1, and other components 83.96 cm upstream the 
+             beamline.
+          3. Changed layout of the 1st passive collimator to a composite W/Pb:
+	      - the inner part is a W  box,  5.08 x  5.08 x 20.0 cm3
+              - the outer part is a Pb box, 30.48 x 30.48 x 20.0 cm3 
+          4. Added  the vacuum beam pipe (Flange1 compositon) in front of the 1st sweeping 
+             magnet:
+              - use 150 micron Kapton entrance window
+              - vaccuum goes all the way downstream the beamline until the GlueX detector.
+          5. Modified the layout of the 1st sweeping magnet:
+              - the outer dimensions are 29.2 x 24.8 x 355.6 cm3
+              - the gap size is 10.22 x 4.9 cm2 
+              - the field inside the gap is 0.23 T (integrated field is 0.82 Tm)
+              - the elliptical vacuum pipe goes through the magnet. The semi-axes of the pipe 
+              are 4.95 cm and 2.29 cm.        
+          6. Added the concrete blocks around the 1st sweeping magnet, composition ConcreteWall1. 
+             The size of the wall is 101.6 x 147.32 x 121.92 cm3.
+          7. Added the composition Flange2 to connect the 1st sweeping magnet with a vacuum chamber.
+          8. Added a vacuum chamber after the 1st sweeping magnet with the following dimensions:
+              - 50.8 cm long tube with the inner and outer radii of Rin = 9.83 cm and Rout = 9.85.
+          9. Added the small lead wall after the vacuum chamber, composition LeadBand1.
+         10. Added the composition Flange3 to connect the vacuum pipe between the lead band and the
+             2nd collimatoor.
+         11. Changed material of the 2nd collimator from Nickel to Iron. The default pinhole 
+             diameter was changed from 1 cm to 0.6 cm.
+         12. Added the composition Flange4 to connect the vacuum pipe between the 2nd collimator and
+             the 2nd sweeping magnet.
+         13. Changed the layout of the second sweeping magnet:
+              - outer dimensions are 42 x 20.8 cm2
+              - the gap size is 20.3 x 5 cm2, the field in the gap is 0.23 T
+              - 1.75 cm radius vacuum beam pipe goes through the magnet.         
+         14. Added the composition Flange5 to connect 2nd the sweeping magnet with the vacuum beam 
+             pipe.           
+         15. Added a 1m long vacuum beam pipe. The inner and outer radii are 2.38 and 2.54 cm, 
+             respectively.
+         16. Added the small lead wall (composition LeadBand2), 81.28 x 20.32 x 10.16 cm3.
+         17. Placed the vertical plane DET2 after the lead wall. 
+         18. Added the composition Flange6 to connect the vacuum pipe between the lead wall and 
+             a pair spectrometer converter box.          
+         19. Added the pair spectrometer converter. The converter thickness and material can be set
+             in the box 'PTAR'   <box  name="PTAR" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />.
+         20. Added the composition Flange7 to connect the vacuum pipe between the converter and 
+             the concrete wall.
+         21. Modified the size of the concrete shielding wall to 450.0 x 270.0 x 121.92 cm3.
+             Added passage to the collimator cave.
+         22. Decreased thickness of the lead wall to 5.08 cm (size of the lead brick).
+              
+     Revision 2.2  12/22/2008
+       Modified the composition 'beamPipe'. Now 'beamPipe' extends the vacuum from the 
+       pair spectrometer to the position of the target.
+
+     Revision 3.0  3/2/2011
+       Large group of revisions, to reflect the beamline geometry and shielding
+       in the engineering drawings for the cave, and the new pair spectrometer.
+
+     Revision 3.1 9/6/2013
+       Updates for compatibility with geant4 -rtj
+       a) Many small shifts to various volumes to eliminate overlaps.
+       b) Changes to dimensions of the active collimator wedges, and even
+          the number of pins per row, so that all overlaps are eliminated.
+
+     Revision 3.2 12/12/2016
+       Updates to introduce the triplet polarimeter -rtj
+       a) renamed downstream PS converter target from PTAR to CONV
+       b) reserved the name PTAR for the triplet polarimeter target
+       c) incorporated a detailed geometric model of the triplet polarimeter
+          from the ASU group into the beamline geometry
+
+     Revision 3.3 3/27/2017
+     Added TAC and some material downstream the FCAL - A.S. 
+     - FCAL dark box window, FCAL platform pipe with plexiglass window, beam 
+     - intensity monitor, and TAC
+
+
+
+<HDDS specification="v1.0" xmlns="http://www.gluex.org/hdds">
+-->
+
+<section name        = "BeamLine"
+         version     = "3.2"
+         date        = "2016-12-12"
+         author      = "R.T. Jones"
+         top_volume  = "collimatorPackage"
+         specification = "v1.0">
+
+<!-- Origin of collimatorPackage is center of the entrance face of the
+     primary collimator.  					-->
+
+  <composition name="collimatorPackage">
+    <posXYZ volume="ShieldedCollimator" X_Y_Z="0.0  0.0  400.0" />
+  </composition>
+
+  <box name="SHLD" X_Y_Z="550.  550.  1300." material="Concrete"/>
+  <composition name="ShieldedCollimator" envelope="SHLD">
+    <posXYZ volume="pipeFromTaggerHall" X_Y_Z="0.0  0.0  -625.0" />
+    <posXYZ volume="collimatorCave" X_Y_Z="0.0  35.0  25.0" />
+  </composition>  
+ 
+  <box  name="CAVE" X_Y_Z="450. 270. 1250." material="Air" />
+  <composition name="collimatorCave" envelope="CAVE">
+    <posXYZ volume="collimatorStack" X_Y_Z="0.0 -35.0 -500.0"/>     
+<!--  <posXYZ volume="DET2" X_Y_Z="0.0  0.0  225.0" /> -->
+    <posXYZ volume="DET3" X_Y_Z="0.0  132.0  0.0" />
+  </composition>
+ 
+  <composition name="collimatorSubCave">
+    <posXYZ volume="collimatorStack" />
+  </composition>
+
+  <composition name="collimatorStack">
+    <posXYZ volume="BeamPipe0"     X_Y_Z="0.0  0.0  -125.0"  />
+    <!--posXYZ volume="PFLD"          X_Y_Z="0.0  0.0  -99.0"  />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -97.0"   />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -93.0"   /-->
+    <posXYZ volume="DET1"          X_Y_Z="0.0  0.0  -49.46"  />
+    <posXYZ volume="ColDetector"   X_Y_Z="0.0  0.0  -46.16"  />
+    <posXYZ volume="PrimaryCol"    X_Y_Z="0.0  0.0  -33.96"  />
+    <posXYZ volume="Flange1"       X_Y_Z="0.0  0.0   11.52"  />
+    <posXYZ volume="sweepMagnet1"  X_Y_Z="0.0  0.0   189.32" />
+    <posXYZ volume="ConcreteWall1" X_Y_Z="0.0  0.0   107.96" />
+    <posXYZ volume="Flange2"       X_Y_Z="0.0  0.0   367.12" />
+    <posXYZ volume="VacuumChamber" X_Y_Z="0.0  0.0   426.54" />
+    <posXYZ volume="LeadBand1"     X_Y_Z="0.0  0.0   457.02" />
+    <posXYZ volume="Flange3"       X_Y_Z="0.0  0.0   462.10" />
+    <posXYZ volume="COL2"          X_Y_Z="0.0  0.0   555.04" />
+    <posXYZ volume="Flange4"       X_Y_Z="0.0  0.0   580.44" />
+    <posXYZ volume="sweepMagnet2"  X_Y_Z="0.0  0.0   630.28" />
+    <posXYZ volume="Flange5"       X_Y_Z="0.0  0.0   648.28" />
+    <posXYZ volume="BeamPipe1"     X_Y_Z="0.0  0.0   712.28" />
+    <posXYZ volume="LeadBand2"     X_Y_Z="0.0  0.0   743.52" />
+    <posXYZ volume="DET2"          X_Y_Z="0.0  35.0  748.65" /> 
+    <posXYZ volume="Flange6"       X_Y_Z="0.0  0.0   748.70" />
+    <posXYZ volume="TripletPolar"  X_Y_Z="0.0 0.0    820.00" />
+    <posXYZ volume="Flange7"       X_Y_Z="0.0  0.0   840.954" />
+    <posXYZ volume="ConcreteWall2" X_Y_Z="0.0  33.0  941.24" />
+    <posXYZ volume="shieldingWall" X_Y_Z="0.0  35.0 1004.74" />     
+    <!--    <posXYZ volume="TargetBox"     X_Y_Z="0.0  0.0 1085.00" />   -->
+    <posXYZ volume="BeamPipe2"     X_Y_Z="0.0  0.0  1066.668" /> 
+  </composition>
+  
+<!-- Beam Pipe 0 -->
+
+  <composition name="pipeFromTaggerHall" envelope="PFTH">
+    <posXYZ volume="PFTV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PFTH" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="PFTV" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipe0">
+    <posXYZ volume="BeamPipeTube"    X_Y_Z="0.0  0.0  25.0" />
+    <posXYZ volume="BeamPipeFlange1" X_Y_Z="0.0  0.0  48.58" />
+    <posXYZ volume="BeamPipeExitWindow" X_Y_Z="0.0  0.0  50.0" />
+    <posXYZ volume="BeamPipeFlange2" X_Y_Z="0.0  0.0  51.42"  />
+  </composition>
+
+  <composition name="BeamPipeTube" envelope="BPTO">
+    <posXYZ volume="BPTI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPTO" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="BPTI" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipeFlange1">
+    <posXYZ volume="BFO1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BFO1" Rio_Z="12.7   15.24  2.84" material="Iron" />
+
+  <composition name="BeamPipeExitWindow">
+    <posXYZ volume="FCAP" X_Y_Z="0.0  0.0  0.0125"/>
+  </composition>
+
+  <tubs name="FCAP" Rio_Z="0.0   10.16   0.025" material="Kapton" />
+
+  <composition name="BeamPipeFlange2">
+    <posXYZ volume="BFO2" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="BFO2" Rio_Z="10.16   15.24   2.84"  material="Iron" />
+
+
+<!-- Primary Collimator -->
+
+  <composition name="PrimaryCol" envelope="PCPB">
+    <posXYZ volume="TungstenInsert" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="PCPB"  X_Y_Z="30.48  30.48  20." material="Lead" />
+
+  <composition name="TungstenInsert" envelope="PCTT">
+    <posXYZ volume="PCTH" X_Y_Z="0.0 0.0 0.0" />
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.02865 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.05730 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.11459 0 0" /-->
+  </composition>
+  <composition name="PrimaryCollimatorAperture" envelope="PCTH">
+    <posXYZ volume="PCTI" X_Y_Z="0.0 0.0 -5.0" />
+  </composition>
+
+  <box  name="PCTT"  X_Y_Z="5.08   5.08   20." material="Tungsten" />
+  <!--tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" /-->
+  <tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" />
+  <tubs name="PCTI"  Rio_Z="0.05   0.25   10." material="Tungsten" 
+        comment="pin-hole insert for reduced intensity running" />
+
+
+<!-- Flange 1 -->
+
+  <composition name="Flange1">
+    <posXYZ volume="FlangeOneDisk" X_Y_Z="0.0  0.0  -7.72" />
+    <posXYZ volume="FlangeOneWindow" X_Y_Z="0.0  0.0  -6.65" />
+    <posXYZ volume="FlangeOnePipe" X_Y_Z="0.0  0.0  -3.325" />
+  </composition>
+
+  <composition name="FlangeOneDisk">
+    <posXYZ volume="FOI1" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="FOI1" Rio_Z="1.27  8.57  2.14"  material="Iron" />
+
+  <composition name="FlangeOneWindow">
+    <posXYZ volume="F1CP" X_Y_Z="0.0  0.0  -0.0075"/>
+  </composition>
+
+  <tubs name="F1CP" Rio_Z="0.0   1.27  0.015" material="Kapton" />
+
+  <composition name="FlangeOnePipe" envelope="FOPO">
+    <posXYZ volume="FOPI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FOPO" Rxy_Z="5.11  2.45   6.65" material="Iron" />
+  <eltu name="FOPI" Rxy_Z="4.95  2.29   6.65" material="Vacuum" />
+
+
+<!-- 1st Sweeping Magnet -->
+
+  <composition name="sweepMagnet1" envelope="MAG1">
+    <posXYZ volume="POL1" X_Y_Z="0.0 +7.425 0.0" />
+    <posXYZ volume="POL1" X_Y_Z="0.0 -7.425 0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="-9.855 0.0  0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="+9.855 0.0  0.0" />
+    <posXYZ volume="MagnetPipe1" X_Y_Z="0.0  0.0  0.0" />
+  </composition> 
+
+  <box name="MAG1" X_Y_Z="29.2 24.8 355.6" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <box name="POL1" X_Y_Z="29.2  9.95  355.6" material="Iron" />
+  <box name="GAP1" X_Y_Z="9.49  4.9   355.6" material="Iron" />
+
+  <composition name="MagnetPipe1" envelope="MPO1">
+    <posXYZ volume="MPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="MPO1" Rxy_Z="5.11  2.45  355.6" material="Iron" />
+  <eltu name="MPI1" Rxy_Z="4.95  2.29  355.6" material="Vacuum" />
+
+
+<!-- Concrete Wall around the 1st sweeping magnet -->
+
+  <composition name="ConcreteWall1">
+    <posXYZ volume="WTOP" X_Y_Z="0.0   +30.3  0.0" />
+    <posXYZ volume="WBOT" X_Y_Z="0.0   -56.2  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="+32.7   0.0  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="-32.7   0.0  0.0" />
+  </composition> 
+
+  <box name="WTOP" X_Y_Z="101.6  35.8  121.92" material="Concrete" />
+  <box name="WBOT" X_Y_Z="101.6  87.6  121.92" material="Concrete" />
+  <box name="WSID" X_Y_Z="36.2   24.8  121.92" material="Concrete" />
+
+
+<!-- Flange 2 -->
+
+  <composition name="Flange2">
+    <posXYZ volume="FlangeTwoDisk1" X_Y_Z="0.0  0.0  2.29" />
+    <posXYZ volume="FlangeTwoDisk2" X_Y_Z="0.0  0.0  6.72"/>
+    <posXYZ volume="FlangeTwoDisk3" X_Y_Z="0.0  0.0  16.88"/>
+    <posXYZ volume="FlangeTwoDisk4" X_Y_Z="0.0  0.0  27.04"/>
+    <posXYZ volume="FlangeTwoDisk5" X_Y_Z="0.0  0.0  31.6"/>
+  </composition>
+
+  <composition name="FlangeTwoDisk1" envelope="FTO1">
+    <posXYZ volume="FTI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FTO1" Rxy_Z="5.11  2.45   4.58" material="Iron" />
+  <eltu name="FTI1" Rxy_Z="4.95  2.29   4.58" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk2" envelope="FTO2">
+    <posXYZ volume="FTI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO2" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI2" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk3" envelope="FTO3">
+    <posXYZ volume="FTI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO3" Rio_Z="0.0  6.21  16.04" material="Iron" />   
+  <tubs name="FTI3" Rio_Z="0.0  6.19  16.04" material="Vacuum" /> 
+
+  <composition name="FlangeTwoDisk4" envelope="FTO4">
+    <posXYZ volume="FTI4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO4" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI4" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk5" envelope="FTO5">
+    <posXYZ volume="FTI5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO5" Rio_Z="0.0  6.35   4.84" material="Iron" />
+  <tubs name="FTI5" Rio_Z="0.0  6.19   4.84" material="Vacuum" />
+
+
+<!-- Vacuum chamber after the 1st sweeping magnet-->
+
+  <composition name="VacuumChamber">
+    <posXYZ volume="VacuumChambDisk1" X_Y_Z="0.0 0.0 -25.30"/>
+    <posXYZ volume="VacuumChambDisk2" X_Y_Z="0.0 0.0  0.0"/>
+    <posXYZ volume="VacuumChambDisk3" X_Y_Z="0.0 0.0  25.30"/>
+  </composition>
+
+  <composition name="VacuumChambDisk1" envelope="VCO1">
+    <posXYZ volume="VCI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO1" Rio_Z="0.0  9.85   0.2" material="Iron" />
+  <tubs name="VCI1" Rio_Z="0.0  6.19   0.2" material="Vacuum" />
+
+  <composition name="VacuumChambDisk2" envelope="VCO2">
+    <posXYZ volume="VCI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO2" Rio_Z="0.0  9.85  50.40" material="Iron" />
+  <tubs name="VCI2" Rio_Z="0.0  9.83  50.40" material="Vacuum" />
+
+  <composition name="VacuumChambDisk3" envelope="VCO3">
+    <posXYZ volume="VCI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO3" Rio_Z="0.0  9.85  0.2" material="Iron" />
+  <tubs name="VCI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+
+<!-- Lead Band 1 -->
+
+  <composition name="LeadBand1" envelope="LBD1">
+    <posXYZ volume="LeadBandPipe1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe1" envelope="LBO1">
+    <posXYZ volume="LBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD1" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO1" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI1" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 3 -->
+
+  <composition name="Flange3">
+    <posXYZ volume="FlangeThreeDisk1" X_Y_Z="0.0  0.0  24.56" />
+    <posXYZ volume="FlangeThreeDisk2" X_Y_Z="0.0  0.0  50.70"/>
+    <posXYZ volume="FlangeThreeDisk3" X_Y_Z="0.0  0.0  55.78"/>
+    <posXYZ volume="FlangeThreeDisk4" X_Y_Z="0.0  0.0  60.86"/>
+    <posXYZ volume="FlangeThreeDisk5" X_Y_Z="0.0  0.0  64.99"/>
+  </composition>
+
+  <composition name="FlangeThreeDisk1" envelope="F3O1">
+    <posXYZ volume="F3I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O1" Rio_Z="0.0  2.54  49.12" material="Iron" />
+  <tubs name="F3I1" Rio_Z="0.0  2.38  49.12" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk2" envelope="F3O2">
+    <posXYZ volume="F3I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk3" envelope="F3O3">
+    <posXYZ volume="F3I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F3I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk4" envelope="F3O4">
+    <posXYZ volume="F3I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk5" envelope="F3O5">
+    <posXYZ volume="F3I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O5" Rio_Z="0.0  2.54   5.1" material="Iron" />
+  <tubs name="F3I5" Rio_Z="0.0  2.38   5.1" material="Vacuum" />
+
+
+<!-- 2nd Collimator -->
+
+  <composition name="COL2" envelope="OCOL">
+    <posXYZ volume="ICOL" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="OCOL" Rio_Z="0.0  10.0  50.8" material="Iron" />
+  <tubs name="ICOL" Rio_Z="0.0   0.5  50.8" material="Vacuum" />
+
+<!-- Flange 4 -->
+
+  <composition name="Flange4">
+    <posXYZ volume="FlangeFourDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFourDisk2" X_Y_Z="0.0  0.0  9.84"/>
+    <posXYZ volume="FlangeFourDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFourDisk4" X_Y_Z="0.0  0.0  20.0"/>
+    <posXYZ volume="FlangeFourDisk5" X_Y_Z="0.0  0.0  26.71"/>
+  </composition>
+
+  <composition name="FlangeFourDisk1" envelope="F4O1">
+    <posXYZ volume="F4I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F4I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+
+  <composition name="FlangeFourDisk2" envelope="F4O2">
+    <posXYZ volume="F4I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk3" envelope="F4O3">
+    <posXYZ volume="F4I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F4I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFourDisk4" envelope="F4O4">
+    <posXYZ volume="F4I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I4" Rio_Z="0.0  1.745  3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk5" envelope="F4O5">
+    <posXYZ volume="F4I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O5" Rio_Z="0.0  1.905   10.26" material="Iron" />
+  <tubs name="F4I5" Rio_Z="0.0  1.745   10.26" material="Vacuum" />
+
+
+<!-- 2nd Sweeping Magnet -->
+
+  <composition name="sweepMagnet2">
+    <posXYZ volume="Core" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Core" envelope="POL2">
+    <posXYZ volume="Aperture" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Aperture" envelope="GAP2">
+    <posXYZ volume="MagnetPipe2" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="POL2" X_Y_Z="42.0  20.8  36.0" material="Iron" />
+  <box name="GAP2" X_Y_Z="20.3   5.0  36.0" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <composition name="MagnetPipe2" envelope="MPO2">
+    <posXYZ volume="MPI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="MPO2" Rio_Z="0.0  1.905  36.0" material="Iron" />
+  <tubs name="MPI2" Rio_Z="0.0  1.745  36.0" material="Vacuum" />
+
+
+<!-- Flange 5 -->
+
+  <composition name="Flange5">
+    <posXYZ volume="FlangeFiveDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFiveDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeFiveDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFiveDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeFiveDisk5" X_Y_Z="0.0  0.0  29.71"/>
+  </composition>
+
+  <composition name="FlangeFiveDisk1" envelope="F5O1">
+    <posXYZ volume="F5I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O1" Rio_Z="0.0  1.905  8.26" material="Iron" />
+  <tubs name="F5I1" Rio_Z="0.0  1.745  8.26" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk2" envelope="F5O2">
+    <posXYZ volume="F5I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk3" envelope="F5O3">
+    <posXYZ volume="F5I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F5I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk4" envelope="F5O4">
+    <posXYZ volume="F5I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk5" envelope="F5O5">
+    <posXYZ volume="F5I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O5" Rio_Z="0.0  2.54  16.26" material="Iron" />
+  <tubs name="F5I5" Rio_Z="0.0  2.38  16.26" material="Vacuum" />
+
+
+<!-- Beam Pipe1 -->
+
+  <composition name="BeamPipe1" envelope="BPO1">
+    <posXYZ volume="BPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPO1" Rio_Z="0.0  2.54  52.32" material="Iron" />
+  <tubs name="BPI1" Rio_Z="0.0  2.38  52.32" material="Vacuum" />
+
+<!-- Lead Band 2 -->
+
+  <composition name="LeadBand2" envelope="LBD2">
+    <posXYZ volume="LeadBandPipe2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe2" envelope="LBO2">
+    <posXYZ volume="LBI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD2" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO2" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI2" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 6 -->
+
+<!-- Without DET2
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  25.71"/>
+  </composition>
+-->
+
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.08" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.74" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.82"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  19.9" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  35.98"/>
+  </composition>
+
+  <composition name="FlangeSixDisk1" envelope="F6O1">
+    <posXYZ volume="F6I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+<!-- Without DET2
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+-->
+
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.16" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk2" envelope="F6O2">
+    <posXYZ volume="F6I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk3" envelope="F6O3">
+    <posXYZ volume="F6I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F6I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSixDisk4" envelope="F6O4">
+    <posXYZ volume="F6I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk5" envelope="F6O5">
+    <posXYZ volume="F6I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O5" Rio_Z="0.0  2.54   29.0" material="Iron" />
+  <tubs name="F6I5" Rio_Z="0.0  2.38   29.0" material="Vacuum" />
+
+
+  <composition name="TargetBox">
+    <posXYZ volume="TargetBoxDisk1" X_Y_Z="0.0 0.0 -10.9"/>
+    <posXYZ volume="TargetBoxDisk2" X_Y_Z="0.0 0.0  0.0" />
+    <posXYZ volume="TargetBoxDisk3" X_Y_Z="0.0 0.0  10.9"/>
+  </composition>
+
+  <composition name="TargetBoxDisk1" envelope="TBO1">
+    <posXYZ volume="TBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO1" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI1" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+  <composition name="TargetBoxDisk2" envelope="TBO2">
+    <posXYZ volume="TargetInnerBox" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="TargetInnerBox" envelope="TBI2">
+    <posXYZ volume="CONV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO2" X_Y_Z="22.0  20.0  21.6" material="Iron" />
+  <box name="TBI2" X_Y_Z="21.6  19.6  21.6" material="Vacuum" />
+
+  <composition name="TargetBoxDisk3" envelope="TBO3">
+    <posXYZ volume="TBI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO3" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+  <box  name="CONV" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />
+
+
+
+
+
+
+<!-- Flange 7 -->
+
+  <composition name="Flange7">
+    <posXYZ volume="FlangeSevenDisk1" X_Y_Z="0.0  0.0  8.8721" />
+    <posXYZ volume="FlangeSevenDisk2" X_Y_Z="0.0  0.0  19.3224" />
+    <posXYZ volume="FlangeSevenDisk3" X_Y_Z="0.0  0.0  24.4024" />
+    <posXYZ volume="FlangeSevenDisk4" X_Y_Z="0.0  0.0  29.4824" />
+    <posXYZ volume="FlangeSevenDisk5" X_Y_Z="0.0  0.0  35.1924" />
+  </composition>
+
+  <composition name="FlangeSevenDisk1" envelope="F7O1">
+    <posXYZ volume="F7I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O1" Rio_Z="0.0  2.54  17.7424" material="Iron" />
+  <tubs name="F7I1" Rio_Z="0.0  2.38  17.7424" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk2" envelope="F7O2">
+    <posXYZ volume="F7I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk3" envelope="F7O3">
+    <posXYZ volume="F7I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F7I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk4" envelope="F7O4">
+    <posXYZ volume="F7I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk5" envelope="F7O5">
+    <posXYZ volume="F7I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O5" Rio_Z="0.0  2.54   8.26" material="Iron" />
+  <tubs name="F7I5" Rio_Z="0.0  2.38   8.26" material="Vacuum" />
+
+
+<!-- Concrete Wall -->
+
+  <composition name="ConcreteWall2" envelope="BLC2">
+    <posXYZ volume="ENTR" X_Y_Z="-179.0  0.0 -30.46"/>
+    <posXYZ volume="Block2Hole" X_Y_Z="0.0 -33.0 0.0"/>
+  </composition>
+
+  <box name="ENTR" X_Y_Z="92.0 266.0 61.0" material="Air" />
+
+  <composition name="Block2Hole" envelope="OBHO">
+    <posXYZ volume="IBHO"  X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="BLC2" X_Y_Z="450.0 266.0 121.92" material="Concrete" />
+  <tubs name="OBHO" Rio_Z="0.0  2.54  121.92" material="Iron" />
+  <tubs name="IBHO" Rio_Z="0.0  2.38  121.92" material="Vacuum" />
+
+
+<!-- Lead Wall -->
+
+  <composition name="shieldingWall" envelope="WALL">
+    <posXYZ volume="WallHole" X_Y_Z="0.0  -35.0  0.0"/>
+  </composition>
+
+  <box name="WALL" X_Y_Z="450. 270. 5.08" material="Lead" />
+
+  <composition name="WallHole" envelope="OWHO">
+    <posXYZ volume="IWHO" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="OWHO" Rio_Z="0.0  2.54 5.08" material="Iron" />
+  <tubs name="IWHO" Rio_Z="0.0  2.38 5.08" material="Vacuum" />
+
+
+<!-- Beam Pipe2 -->
+
+  <composition name="BeamPipe2" envelope="BPO2">
+  <!-- MUST COMMENT OUt either one or the other of the two lines below -->
+    <!-- <posXYZ volume="BeamPipe2Inner" /> enables the photon beam harp -->
+    <posXYZ volume="BPI2" /> <!-- disables the photon beam harp -->
+  </composition>
+  
+  <composition name="BeamPipe2Inner" envelope="BPI2">
+    <posXYZ volume="photonBeamHarp" X_Y_Z="0.0 0.0 -27.38" />
+  </composition>
+  
+  <composition name="photonBeamHarp">
+    <posXYZ volume="PSCV" />
+    <posXYZ volume="PSCH" />
+  </composition>
+
+  <tubs name="BPO2" Rio_Z="0.0  2.54   118.767" material="Iron" />
+  <tubs name="BPI2" Rio_Z="0.0  2.38   118.767" material="Vacuum" />
+    
+  <composition name="PairSpecConverter" envelope="PSCM">
+    <posXYZ volume="PSCV"/>
+    <posXYZ volume="PSCH"/>
+  </composition>
+  
+  <tubs name="PSCM" Rio_Z="0.0 2.38 0.53" material="Vacuum"/>
+  <tubs name="PSCV" Rio_Z="0.0 1.143 0.01" material="Aluminum"/>
+  <tubs name="PSCH" Rio_Z="1.143 2.38 0.53" material="Iron"/>
+
+  <tubs name="DET1" Rio_Z="0.   50.  2." material="Air" />
+  <box name="DET2" X_Y_Z=" 450. 270. 0.1" material="Vacuum" />
+  <box name="DET3" X_Y_Z=" 450. 2. 918." material="Air" />
+
+  
+<!-- The composition 'beamPipe' extends the vacuum from the pair 
+     spectrometer to the position of the target.
+
+     Origin of beamPipe is center of the hall.
+-->
+
+  <composition name="beamPipe">
+<!--    <posXYZ volume="DET4"     X_Y_Z="  0.0     0.0 -1400.0"/> -->
+    <posXYZ volume="DET5"     X_Y_Z="  0.0     0.0  1400.0"/> 
+    <posXYZ volume="TAC1" X_Y_Z="150.0  -350.0  1225.0" />  
+    <posXYZ volume="DarkWindow" X_Y_Z="  150.0  -350.0  320.0" />
+    <posXYZ volume="PlatformPipe" X_Y_Z="150.0  -350.0  650."/>
+    <posXYZ volume="PlexWindow" X_Y_Z="150.0  -350.0  830."/>
+    <posXYZ volume="IntMonitor" X_Y_Z="150.0  -350.0  834."/>
+    <posXYZ volume="DET6"     X_Y_Z="  0.0   600.0     0.0"/>
+    <!--posXYZ volume="DET7"     X_Y_Z="  0.0     0.0  -705.0"/--> 
+    <posXYZ volume="HallBellows" X_Y_Z="150.0 -350.0 -1223.287"/>
+    <posXYZ volume="HallPipe" X_Y_Z="150.0  -350.0  -1026.77"/>
+    <!-- Plastic scintillator for beam diagonistics -->
+    <!--posXYZ volume="DET8" X_Y_Z="150 -350.0 -834.0 "/-->
+  </composition>
+
+  <composition name="DarkWindow">
+    <posXYZ volume="DBOW" X_Y_Z="  0.0  0.0  0.0" />
+    <posXYZ volume="DBEW" X_Y_Z="  0.0  0.0  0.0" />
+  </composition>
+
+  <tubs name="DBOW" Rio_Z="20.0  60.0  0.3"  material="Aluminum"/>
+  <tubs name="DBEW" Rio_Z="0.0   20.0  0.01" material="Tedlar"/>
+
+  <composition name="PlatformPipe">
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0  -176.5127" />
+    <posXYZ volume="PipeSection" X_Y_Z="0.0 0.0 0.0" />
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0   176.5127" />
+  </composition>
+
+  <tubs name="PPWD" Rio_Z="0.0   20.32  0.0254" material="Kapton" />
+
+  <composition name="PipeSection" envelope="PPOV">
+    <posXYZ volume="PPIV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PPOV" Rio_Z="0.0   20.32  353.0" material="Iron" />
+  <tubs name="PPIV" Rio_Z="0.0   20.04  353.0" material="Vacuum" />
+
+  <composition name="PlexWindow">
+    <posXYZ volume="PPPW" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="IntMonitor" >
+    <posXYZ volume="INTM" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box  name="INTM" X_Y_Z="2  6  1" material="Scintillator"  />
+
+  <tubs name="PPPW" Rio_Z="0.0   20.32  0.3" material="Plexiglas" />
+
+  <box  name="TAC1" X_Y_Z="20  20  45" material="leadGlassF800" sensitive="true" />
+
+
+  <box name="DET4" X_Y_Z="1700.0  1200.0  2.0" material="Vacuum" />
+  <box name="DET5" X_Y_Z="1700.0  1198.0  2.0" material="Air" />
+  <box name="DET6" X_Y_Z="1700.0  2.0  3000.0" material="Air" />
+  <!--box name="DET7" X_Y_Z="1700.0  1198.0  2.0" material="Air" /-->
+  <tubs name="DET7" Rio_Z="0.0 1.7399  2.0" material="Vacuum"
+        comment="disk detector inside beam pipe at target entrance" />
+  <box name="DET8" X_Y_Z="10.0 10.0 1.0" material="Scintillator" sensitive="true"/>
+
+<!-- Hall bellows -->
+<composition name="HallBellows" envelope="BLWO">
+  <posXYZ volume="BLWI" X_Y_Z="0.0 0.0 -3.5011"/>
+</composition>
+
+<pcon name="BLWO" material="Iron">
+  <polyplane Rio_Z="0.0 1.90500 -13.4"/>
+  <polyplane Rio_Z="0.0 1.90500 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 6.3978"/>
+</pcon>
+
+<tubs name="BLWI" Rio_Z="0. 1.7399 19.7978" material="Vacuum"/>
+
+<!-- Hall Pipe -->
+  <composition name="HallPipe" envelope="OHPI" >
+    <!--posXYZ volume="IHPI" X_Y_Z="0 0 98.6305"/-->
+    <posXYZ volume="InnerHallPipe" X_Y_Z="0.0 0.0 98.6305"/> 
+  </composition>
+
+  <composition name="InnerHallPipe" envelope="IHPI">
+    <posXYZ volume="DET7" X_Y_Z="0 0 280.0"/> 
+    <!--posXYZ volume="CAP1" X_Y_Z="0.0  0.0  190.11265" /-->
+  </composition>
+
+
+  <pcon name="OHPI" material="Iron">
+    <polyplane Rio_Z="0.0 4.27355 -190.1190"/>
+    <polyplane Rio_Z="0.0 4.27355 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +387.380"/>
+  </pcon>
+
+  <tubs name="IHPI" Rio_Z="0.0  1.7399 577.499" material="Vacuum" />
+  <tubs name="CAP1" Rio_Z="0.0  1.7399 0.0127" material="Kapton"/>
+
+<composition name="SixWayCross" envelope="SWCM">
+  <posXYZ volume="sixWayTube" X_Y_Z="0 0 0"/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0 0." rot="0. 180. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 90. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 270. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="90. 0. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="270. 0. 0."/>
+  <posXYZ volume="sixWayBox" X_Y_Z="0. 0. 0."/> 
+</composition>
+
+<box name="SWCM" X_Y_Z="67.9196 67.9196 67.9196" material="Air"
+     comment="Six-way cross mother volume"/>
+<pcon name="SWCP" material="StainlessSteel" comment="Vacuum pipe for 6-way cross">
+  <polyplane Rio_Z="0. 20.32 20.32"/>
+  <polyplane Rio_Z="0. 20.32 32.258"/>
+  <polyplane Rio_Z="0. 22.504 32.258"/>
+  <polyplane Rio_Z="0. 22.504 33.9598"/>
+</pcon>
+  
+<composition name="sixWayTube" envelope="SWCP">
+  <posXYZ volume="SWC2" X_Y_Z="0.0 0.0 27.1399"/>
+</composition>
+
+<composition name="sixWayBox" envelope="SWCB">
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 -20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 -20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="20.08125 0. 0." rot="0 90 0 "/>
+  <posXYZ volume="SWC1" X_Y_Z="-20.08125 0. 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeMotherVolume" X_Y_Z="0. 0. 0." />
+</composition>
+
+<composition name="coldCubeMotherVolume" envelope="CBXM">
+  <posXYZ volume="CBX1" X_Y_Z="0. -7.712  0."/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.1444"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.3032"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 -12.1444"/>
+  <posXYZ volume="CBXS" X_Y_Z="12.1444 4.28 0."/>
+  <posXYZ volume="CBXS" X_Y_Z="-12.1444 4.28 0."/>
+  <posXYZ volume="coldCubeTopPlate" X_Y_Z="0. 16.272 0." rot="90 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 -11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="11.9856 4.28 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="-11.9856 4.28 0." rot="0 90 0"/>
+</composition>
+
+<composition name="coldCubeBeamPlate" envelope="CBXB">
+  <posXYZ volume="CBH0" X_Y_Z="0. -4.2926 0."/>
+</composition>
+
+<composition name="coldCubeSidePlate" envelope="CBSP">
+  <posXYZ volume="CBH2" X_Y_Z="0. 0. 0."/>
+</composition>
+
+<composition name="coldCubeTopPlate" envelope="CHXT">
+  <posXYZ volume="CBH1" X_Y_Z="0. 0. 0." />
+</composition>
+
+<box name="CBSP" X_Y_Z="23.8124 23.8124 0.15875" material="Copper"/>
+<box name="CHXT" X_Y_Z="24.13 24.13 0.15875" material="Copper"/>
+<tubs name="CBH1" Rio_Z="0. 10.795 0.15875" material="Vacuum"/>
+<tubs name="CBH0" Rio_Z="0 1.27 0.15875" material="Vacuum" 
+      comment="Hole for beam"/>
+<box name="CBH2" X_Y_Z="19.05 19.05 0.15875" material="Vacuum"/>
+<box name="CBXB" X_Y_Z="21.8948 21.8948 0.15875" material="Copper"/>
+<box name="CBXS" X_Y_Z="0.15875 21.8948 21.8948" material="Copper"/>
+<box name="CBX1" X_Y_Z="24.13 0.15875 24.13" material="Copper"/>
+<box name="CBXM" X_Y_Z="39.685 39.685 39.685" material="Vacuum"/>
+<box name="SWCB" X_Y_Z="40.64 40.64 40.64" material="StainlessSteel"/>
+<tubs name="SWC1" Rio_Z="0 19.84248 0.4775" material="Vacuum"/>
+<tubs name="SWC2" Rio_Z="0. 19.84248 13.6398" material="Vacuum"/>
+
+<!-- Approximation for the beam profiler -->
+<box name="PFSC" X_Y_Z="12.8 12.8 0.2" material="Scintillator" sensitive="true"/>
+<box name="PFLD" X_Y_Z="10.0 10.0 0.1" material="Lead"/>
+
+<!-- Following is the definition of the active collimator.  It sits
+     on the upstream end of the primary collimator and acts as an
+     active absorber with segmented detection of the beam intensity.
+-->
+
+  <composition name="ColDetector" envelope="INSU">
+    <posXYZ volume="ColAssemblyFinal" X_Y_Z="0.0 0.0 0.50"/>
+    <posXYZ volume="HOUF" X_Y_Z="0.0  0.0  -1.85"/>
+  </composition>
+
+  <composition name="ColAssemblyFinal" envelope="HOUS">
+    <posXYZ volume="ColAssemblyInitial" X_Y_Z="0.0  0.0  -0.15"/>
+  </composition>
+  
+  <composition name="ColAssemblyInitial" envelope="AIRH">
+    <mposPhi volume="DIV1" ncopy="4" Phi0="0" dPhi="90" R_Z="3.375 0."/>  
+    <mposPhi volume="DIV2" ncopy="4" Phi0="45" dPhi="90"/>  
+    <mposPhi volume="innerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+    <mposPhi volume="outerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+  </composition>
+
+  <tubs name="INSU" Rio_Z="0.25   7.36  4.20" material="BoronNitride"/>
+ 
+  <tubs name="HOUS" Rio_Z="0.25   6.70  3.20" material="Aluminum" />
+ 
+  <tubs name="HOUF" Rio_Z="0.25   6.85  0.50" material="Aluminum"/>
+ 
+  <tubs name="AIRH" Rio_Z="0.25   6.5002  2.9" material="Air" />
+  <box  name="DIV1" X_Y_Z="6.25  0.1  2.9" material="Aluminum" />
+  <tubs name="DIV2" Rio_Z="2.7   2.8  2.9" profile="-42.870 85.740"
+                                           material="Aluminum" />
+
+  <composition name="innerPinCushionWedge" envelope="ACWI">
+    <posXYZ volume="ACBI" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="innerPinCushionRow_1" X_Y_Z="0.276 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_2" X_Y_Z="0.376 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_3" X_Y_Z="0.476 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_4" X_Y_Z="0.576 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_5" X_Y_Z="0.676 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_6" X_Y_Z="0.776 0.0 0.40" />
+  </composition>
+  <composition name="innerPinCushionRow_1" envelope="AIR1">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_2" envelope="AIR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_3" envelope="AIR3">
+    <mposY volume="PIN1" ncopy="5" Y0="-0.20" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_4" envelope="AIR4">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_5" envelope="AIR5">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_6" envelope="AIR6">
+    <mposY volume="PIN1" ncopy="9" Y0="-0.40" dY="0.10" />
+  </composition>
+
+  <composition name="outerPinCushionWedge" envelope="ACWO">
+    <posXYZ volume="ACBO" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 -1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 +1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 -1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 +1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 -1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 +1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 -1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 +1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_5" X_Y_Z="3.025 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_6" X_Y_Z="3.125 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_7" X_Y_Z="3.225 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_8" X_Y_Z="3.325 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_9" X_Y_Z="3.425 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_10" X_Y_Z="3.525 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_11" X_Y_Z="3.625 0.0 0.40" />
+  </composition>
+  <composition name="outerPinCushionRow_1" envelope="AOR1">
+    <posXYZ volume="PIN1" />
+  </composition>
+  <composition name="outerPinCushionRow_2" envelope="AOR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_3" envelope="AOR3">
+    <mposY volume="PIN1" ncopy="6" Y0="-0.25" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_4" envelope="AOR4">
+    <mposY volume="PIN1" ncopy="10" Y0="-0.45" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_5" envelope="AOR5">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_6" envelope="AOR6">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_7" envelope="AOR7">
+    <mposY volume="PIN1" ncopy="37" Y0="-1.80" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_8" envelope="AOR8">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_9" envelope="AOR9">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_10" envelope="AORA">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_11" envelope="AORB">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+
+  <tubs name="ACWI" Rio_Z="0.25 2.5  2.5" profile="-33. 66."
+         material="Air" comment="active collimator inner wedge" />  
+  <tubs name="ACWO" Rio_Z="2.97  6.0  2.5" profile="-33. 66."
+         material="Air" comment="active collimator outer wedge" />  
+  <tubs name="ACBI" Rio_Z="0.25 2.5  0.8" profile="-32. 64."
+         material="SoftTungsten" comment="inner wedge base plate" />  
+  <tubs name="ACBO" Rio_Z="3.0  6.0  0.8" profile="-30. 60."
+         material="SoftTungsten" comment="outer wedge base plate" />  
+
+  <box name="AIR1" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AIR2" X_Y_Z="0.051 0.40 1.7" material="Air" />
+  <box name="AIR3" X_Y_Z="0.051 0.50 1.7" material="Air" />
+  <box name="AIR4" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AIR5" X_Y_Z="0.051 0.80 1.7" material="Air" />
+  <box name="AIR6" X_Y_Z="0.051 0.90 1.7" material="Air" />
+
+  <box name="AOR1" X_Y_Z="0.051 0.10 1.7" material="Air" />
+  <box name="AOR2" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AOR3" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AOR4" X_Y_Z="0.051 1.00 1.7" material="Air" />
+  <box name="AOR5" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR6" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR7" X_Y_Z="0.051 3.70 1.7" material="Air" />
+  <box name="AOR8" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AOR9" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AORA" X_Y_Z="0.051 4.10 1.7" material="Air" />
+  <box name="AORB" X_Y_Z="0.051 4.10 1.7" material="Air" />
+
+  <box name="PIN1" X_Y_Z="0.051 0.051 1.7" material="SoftTungsten" />
+ 
+<!-- Following is the definition of the triplet polarimeter.  It sits
+     just before of the shielding wall at the downstream end of the
+     collimator cave, and contains a retractable pair conversion target
+     called PTAR. Forward pairs are detected in the pair spectrometer.
+-->
+
+<!-- Origin of TripletPolar is the beam axis midpoint
+     of the polarimeter vacuum box, as set by the outside walls. -->
+
+  <composition name="TripletPolar">
+     <apply region="nullBfield"/>
+     <posXYZ volume="tripletPolar" X_Y_Z="1.5 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tripletPolar">
+     <posXYZ volume="tpolEnclosure" />
+     <posXYZ volume="tpolVacuumBoxFlange" X_Y_Z="6.50 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTPT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTPM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTIT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTIM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFT" X_Y_Z="0.0 -7.91 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTFM" X_Y_Z="-4.0 4.0 +7.91" unit_length="in" />
+     <posXYZ volume="PTFF" X_Y_Z="-6.910 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 -8.5" unit_length="in" />
+     <posXYZ volume="PTKM" X_Y_Z="-4.0 4.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKF" X_Y_Z="-7.550 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTDR" X_Y_Z="7.25 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tpolVacuumBox" envelope="PTB0">
+     <posXYZ volume="tpolRailGuide" X_Y_Z="0.375 5.131 -3.380" unit_length="in" />
+     <posXYZ volume="tpolTargetCarrier" X_Y_Z="0.25 2.146 -3.380" rot="0 180 0" unit_length="in" />
+     <posXYZ volume="tpolTargetMotor" X_Y_Z="-1.625 4.1449 -1.6284" unit_length="in" />
+     <posXYZ volume="tpolRecoilDetectorCard" X_Y_Z="-1.625 0.0 -2.0" rot="0 0 22.5" unit_length="in" />
+     <posXYZ volume="PTA1" X_Y_Z="-1.625 0.0 -1.9796" unit_length="in" />
+     <posXYZ volume="PTA2" X_Y_Z="-1.625 0.0 -1.9795" unit_length="in" />
+     <posXYZ volume="PTA3" X_Y_Z="-1.625 0.0 -1.9794" unit_length="in" />
+     <posXYZ volume="PTA4" X_Y_Z="-1.625 0.0 -2.0204" unit_length="in" />
+     <!-- <posXYZ volume="PTA5" X_Y_Z="-1.625 0.0 -3.3651" unit_length="in" /> -->
+     <posXYZ volume="PTMP" X_Y_Z="0.0 5.8125 0.0" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 -5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 -4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="-5.125 5.745 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="-4.625 5.5525 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 -2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="0.4872 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="-3.7372 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="0.4872 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="-3.7372 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="0.4872 5.5 -0.6216" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="-3.7372 5.5 -0.6216" unit_length="in" />
+  </composition>
+
+  <composition name="tpolEnclosure" envelope="PTBO">
+     <posXYZ volume="tpolVacuumBox" X_Y_Z="0.125 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH3" X_Y_Z="-4.0 4.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH6" X_Y_Z="0.0 -6.125 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH5" X_Y_Z="-6.125 0.0 -2.0" rot="0 90 0" unit_length="in" />
+  </composition>
+
+  
+  <tubs name="PTAR" Rio_Z="0.0 0.375 0.0075" material="Vacuum" 
+	comment="polarimeter converter target" /> 
+  
+  
+  <box name="PTBO" X_Y_Z="12.5 12.5 12.5" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube1" />
+  <box name="PTB0" X_Y_Z="12.25 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube2" />
+  <box name="PTB1" X_Y_Z="0.5 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box flange subtraction" />
+  <box name="PTB2" X_Y_Z="0.5 15.0 17.0" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box door flange" />
+  <box name="PTB3" X_Y_Z="9.25 0.988 0.625" material="Aluminum" unit_length="in"
+                   comment="polarimeter rail guide" />
+  <box name="PTB4" X_Y_Z="9.25 0.312 0.125" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail gap subtraction" />
+  <box name="PTB5" X_Y_Z="9.25 0.365 0.375" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail box subtraction" />
+  <box name="PTB6" X_Y_Z="42.0 42.0 2.0" material="Iron" unit_length="mm"
+                   comment="polarimeter motor plate" />
+  <box name="PTB7" X_Y_Z="5.25 5.792 0.118" material="Aluminum" unit_length="in"
+                   comment="polarimeter target holder" />
+  <box name="PTB8" X_Y_Z="4.325 4.292 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter target holder subtraction" />
+  <tubs name="PTH0" Rio_Z="0.0 21.0 69.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motor" />
+  <tubs name="PTH1" Rio_Z="0.0 10.5 32.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motion gear" />
+  <tubs name="PTH2" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter beam hole subtraction" />
+  <tubs name="PTH3" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter motor hole subtraction" />
+  <tubs name="PTH4" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter auxilliary hole subtraction" />
+  <tubs name="PTH5" Rio_Z="0.0 1.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter feed hole subtraction" />
+  <tubs name="PTH6" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter turbo pump hole subtraction" />
+  <tubs name="PTH7" Rio_Z="0.0 0.375 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter converter tray subtraction" />
+
+  <composition name="tpolVacuumBoxFlange" envelope="PTB2">
+     <posXYZ volume="PTB1" />
+  </composition>
+  <composition name="tpolRailGuide" envelope="PTB3">
+     <posXYZ volume="PTB4" X_Y_Z="0.0 -0.338 0.0" unit_length="in" />
+     <posXYZ volume="PTB5" />
+  </composition>
+  <composition name="tpolTargetDisk" envelope="PTH7">
+     <posXYZ volume="PTAR" />
+  </composition>
+  <composition name="tpolTargetCarrier" envelope="PTB7">
+     <posXYZ volume="PTB8" X_Y_Z="0.4625 0.75 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="1.875 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="0.625 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="-0.625 -2.146 0.0" unit_length="in" />
+  </composition>
+  <composition name="tpolTargetMotor">
+     <posXYZ volume="PTH0" />
+     <posXYZ volume="PTB6" X_Y_Z="0.0 0.0 -35.5" unit_length="mm" />
+     <posXYZ volume="PTH1" X_Y_Z="0.0 0.0 -52.5" unit_length="mm" />
+  </composition>
+  
+  <composition name="tpolRecoilDetector" envelope="PTDE">
+     <posXYZ volume="tpolRecoilRing1" />
+     <posXYZ volume="tpolRecoilRing2" />
+     <posXYZ volume="tpolRecoilRing3" />
+     <posXYZ volume="tpolRecoilRing4" />
+     <posXYZ volume="tpolRecoilRing5" />
+     <posXYZ volume="tpolRecoilRing6" />
+     <posXYZ volume="tpolRecoilRing7" />
+     <posXYZ volume="tpolRecoilRing8" />
+     <posXYZ volume="tpolRecoilRing9" />
+     <posXYZ volume="tpolRecoilRing10" />
+     <posXYZ volume="tpolRecoilRing11" />
+     <posXYZ volume="tpolRecoilRing12" />
+     <posXYZ volume="tpolRecoilRing13" />
+     <posXYZ volume="tpolRecoilRing14" />
+     <posXYZ volume="tpolRecoilRing15" />
+     <posXYZ volume="tpolRecoilRing16" />
+     <posXYZ volume="tpolRecoilRing17" />
+     <posXYZ volume="tpolRecoilRing18" />
+     <posXYZ volume="tpolRecoilRing19" />
+     <posXYZ volume="tpolRecoilRing20" />
+     <posXYZ volume="tpolRecoilRing21" />
+     <posXYZ volume="tpolRecoilRing22" />
+     <posXYZ volume="tpolRecoilRing23" />
+     <posXYZ volume="tpolRecoilRing24" />
+  </composition>
+  <tubs name="PTDE" Rio_Z="11.0 35.0 1.5" material="Vacuum" unit_length="mm" 
+                   comment="container for the triplet polarimeter detector" />
+
+  <composition name="tpolRecoilRing1" envelope="PTRA">
+     <mposPhi volume="PTSA" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="1" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing2" envelope="PTRB">
+     <mposPhi volume="PTSB" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="2" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing3" envelope="PTRC">
+     <mposPhi volume="PTSC" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="3" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing4" envelope="PTRD">
+     <mposPhi volume="PTSD" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="4" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing5" envelope="PTRE">
+     <mposPhi volume="PTSE" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="5" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing6" envelope="PTRF">
+     <mposPhi volume="PTSF" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="6" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing7" envelope="PTRG">
+     <mposPhi volume="PTSG" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="7" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing8" envelope="PTRH">
+     <mposPhi volume="PTSH" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="8" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing9" envelope="PTRI">
+     <mposPhi volume="PTSI" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="9" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing10" envelope="PTRJ">
+     <mposPhi volume="PTSJ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="10" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing11" envelope="PTRK">
+     <mposPhi volume="PTSK" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="11" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing12" envelope="PTRL">
+     <mposPhi volume="PTSL" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="12" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing13" envelope="PTRM">
+     <mposPhi volume="PTSM" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="13" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing14" envelope="PTRN">
+     <mposPhi volume="PTSN" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="14" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing15" envelope="PTRO">
+     <mposPhi volume="PTSO" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="15" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing16" envelope="PTRP">
+     <mposPhi volume="PTSP" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="16" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing17" envelope="PTRQ">
+     <mposPhi volume="PTSQ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="17" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing18" envelope="PTRR">
+     <mposPhi volume="PTSR" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="18" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing19" envelope="PTRS">
+     <mposPhi volume="PTSS" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="19" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing20" envelope="PTRT">
+     <mposPhi volume="PTST" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="20" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing21" envelope="PTRU">
+     <mposPhi volume="PTSU" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="21" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing22" envelope="PTRV">
+     <mposPhi volume="PTSV" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="22" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing23" envelope="PTRW">
+     <mposPhi volume="PTSW" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="23" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing24" envelope="PTRX">
+     <mposPhi volume="PTSX" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="24" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+
+  <tubs name="PTRA" Rio_Z="11 12 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRB" Rio_Z="12 13 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRC" Rio_Z="13 14 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRD" Rio_Z="14 15 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRE" Rio_Z="15 16 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRF" Rio_Z="16 17 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRG" Rio_Z="17 18 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRH" Rio_Z="18 19 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRI" Rio_Z="19 20 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRJ" Rio_Z="20 21 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRK" Rio_Z="21 22 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRL" Rio_Z="22 23 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRM" Rio_Z="23 24 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRN" Rio_Z="24 25 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRO" Rio_Z="25 26 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRP" Rio_Z="26 27 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRQ" Rio_Z="27 28 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRR" Rio_Z="28 29 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRS" Rio_Z="29 30 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRT" Rio_Z="30 31 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRU" Rio_Z="31 32 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRV" Rio_Z="32 33 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRW" Rio_Z="33 34 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRX" Rio_Z="34 35 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTSA" Rio_Z="11 12 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSB" Rio_Z="12 13 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSC" Rio_Z="13 14 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSD" Rio_Z="14 15 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSE" Rio_Z="15 16 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSF" Rio_Z="16 17 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSG" Rio_Z="17 18 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSH" Rio_Z="18 19 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSI" Rio_Z="19 20 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSJ" Rio_Z="20 21 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSK" Rio_Z="21 22 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSL" Rio_Z="22 23 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSM" Rio_Z="23 24 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSN" Rio_Z="24 25 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSO" Rio_Z="25 26 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSP" Rio_Z="26 27 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSQ" Rio_Z="27 28 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSR" Rio_Z="28 29 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSS" Rio_Z="29 30 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTST" Rio_Z="30 31 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSU" Rio_Z="31 32 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSV" Rio_Z="32 33 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSW" Rio_Z="33 34 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSX" Rio_Z="34 35 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+
+  <tubs name="PTA1" Rio_Z="11 35 0.0006" material="Aluminum" unit_length="mm"
+                    comment="called blank1, whatever that is" />
+  <tubs name="PTA2" Rio_Z="11 35 0.0035" material="Silicon" unit_length="mm" 
+                    comment="called blank2, whatever that is" />
+  <tubs name="PTA3" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank3, whatever that is" />
+  <tubs name="PTA4" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank4, whatever that is" />
+  <tubs name="PTA5" Rio_Z="0.0 9.525 0.5" material="Vacuum" unit_length="mm"
+                    comment="called blank5, whatever that is" />
+
+  <composition name="tpolRecoilDetectorCard" envelope="PTCA">
+     <posXYZ volume="tpolRecoilDetector" />
+     <posXYZ volume="PTCH" />
+  </composition>
+
+  <pgon name="PTCA" segments="8" material="FR-4" unit_length="mm"
+                   comment="card that carries the recoil polarimeter detector">
+     <polyplane Rio_Z="0 60 -0.75" unit_length="mm" />
+     <polyplane Rio_Z="0 60 0.75" unit_length="mm" />
+  </pgon>
+  <tubs name="PTCH" Rio_Z="0.0 11.0 1.5" material="Vacuum" unit_length="mm"
+                   comment="central hole through the polarimeter card" />
+  
+  <tubs name="PTPB" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="beam pipe to the upstream/downstream" />
+  <tubs name="PTIB" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="beam vacuum to the upstream/downstream" />
+  <tubs name="PTPF" Rio_Z="1.9375 2.0 1.05" material="Iron" unit_length="in"
+                   comment="feed pipe to the side" />
+  <tubs name="PTIF" Rio_Z="0.0 1.9375 1.05" material="Vacuum" unit_length="in"
+                   comment="feed vacuum to the side" />
+  <tubs name="PTPT" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe" />
+  <tubs name="PTIT" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="turbo pump port vacuum" />
+  <tubs name="PTPM" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="motor port pipe" />
+  <tubs name="PTIM" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="motor port vacuum" />
+  <tubs name="PTPX" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="aux port pipe" />
+  <tubs name="PTIX" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="aux port vacuum" />
+  <tubs name="PTFB" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="beam pipe flange to the upstream/downstream" />
+  <tubs name="PTFX" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="aux port pipe flange" />
+  <tubs name="PTFT" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe flange" />
+  <tubs name="PTFM" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="motor port pipe flange" />
+  <tubs name="PTFF" Rio_Z="2.0 3.0 0.78" material="Iron" unit_length="in"
+                   comment="feed pipe flange" />
+  <tubs name="PTKX" Rio_Z="0.0 1.6875 0.5" material="Iron" unit_length="in"
+                   comment="aux port pipe cap" />
+  <tubs name="PTKM" Rio_Z="0.0 2.250 0.5" material="Iron" unit_length="in"
+                   comment="motor port pipe cap" />
+  <tubs name="PTKF" Rio_Z="0.0 3.0 0.5" material="Iron" unit_length="in"
+                   comment="feed pipe cap" />
+
+  <box name="PTMP" X_Y_Z="10.0 0.375 10.0" material="Aluminum" unit_length="in"
+                   comment="mounting plate" />
+  <box name="PTVR" X_Y_Z="6.0 0.51 0.25" material="Iron" unit_length="in"
+                   comment="vertical rack piece" />
+  <box name="PTHR" X_Y_Z="6.0 0.125 0.75" material="Iron" unit_length="in"
+                   comment="horizontal rack piece" />
+  <box name="PTBR" X_Y_Z="4.75 0.50 0.0625" material="Aluminum" unit_length="in"
+                   comment="horizontal bar piece" />
+  <box name="PTLG" X_Y_Z="0.5 7.987 0.125" material="Aluminum" unit_length="in"
+                   comment="support leg" />
+  <box name="PTVS" X_Y_Z="0.5 2.5 0.25" material="Aluminum" unit_length="in"
+                   comment="vertical support piece" />
+  <box name="PTHS" X_Y_Z="0.5 0.25 2.5" material="Aluminum" unit_length="in"
+                   comment="horizontal support piece" />
+  <box name="PTDR" X_Y_Z="1.0 15.0 17.0" material="Aluminum" unit_length="in"
+                   comment="vacuum box door" />
+
+  <!-- there is no mcfast model of the photon beamline -->
+
+</section>
+
+<!-- </HDDS> -->

--- a/BeamLine_HDDS_34_75.xml
+++ b/BeamLine_HDDS_34_75.xml
@@ -1,0 +1,1642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DOCTYPE HDDS>
+
+  Hall D Geometry Data Base: Beam Line
+  ************************************
+
+     version 1.0: Initial version	-rtj
+
+     Revision 1.1 10/18/2002 
+     -added concrete shielding to the collimator housing 
+     -added the virtual detectors to this code:
+        DET1: disk intercepting entire beam upstream of collimators
+        DET2: plane perpendicular to beam just after second collimator
+        DET3: plane mounted just below the ceiling of collimator cave
+        DET4: plane perpendicular to beam just after entry to hall
+        DET5: plane perpendicular to beam at photon dump end of hall
+        DET6: plane mounted just below the ceiling inside the hall
+        DET7: plane perpendicular to beam just before the target
+     -added a steel tube containing a vacuum that goes from the back of
+      the collimator to the front of the solenoid  
+     -csg-
+
+     Revision 1.2 10/28/2002
+     -revised collimator to the heavy shielding option 
+     -added a steel tube containing a vacuum in the WALL, SHLD and ABS2 volumes
+     -repositioned DET3 to be inside the collimator housing 
+     -removed the BEAM volume from the collimator system
+     -csg-
+
+     Revision 1.3 1/9/2003
+     -shrunk the size of the vacuum tube from r=5.3 to r=2.5 in order to
+      extend the tube into the second steering magnet
+     -csg-
+
+     Revision 1.4 06/16/2003
+     -mid-shielding option
+     -modified DET1, now a cylinder placed in front of primary collimator
+     -added tungsten pin-cushion detector model into simulation
+     -csg- 
+
+     Revision 2.0 05/16/2008
+     -moved DET2 to just after the second collimator, in agreement with
+      the comments below.  Somehow it got misplaced to upstream of the
+      second collimator.  I guess no one was using it until now.
+     -added the volume CONV for the pair conversion target located inside
+      the vacuum pipe just downstream of the second sweep magnet.  Right
+      now it its material is vacuum, but the thickness of 240 microns is
+      chosen to make a 0.1% converter if the material is set to Carbon.
+
+
+     Revision 2.1  12/12/2008, A.S., rtj
+       Made the following changes in the composition 'collimatorStack':
+  	  1. Added the composition BeamPipe0 describing a vacuum beam pipe at the entrance 
+             of the collimator cave:
+              - the beam pipe radius is 12.4 cm
+              - the exit window: 250 micron Kapton with the radius of 10.14 cm. 
+ 	  2. Moved the active collimator, DET1, and other components 83.96 cm upstream the 
+             beamline.
+          3. Changed layout of the 1st passive collimator to a composite W/Pb:
+	      - the inner part is a W  box,  5.08 x  5.08 x 20.0 cm3
+              - the outer part is a Pb box, 30.48 x 30.48 x 20.0 cm3 
+          4. Added  the vacuum beam pipe (Flange1 compositon) in front of the 1st sweeping 
+             magnet:
+              - use 150 micron Kapton entrance window
+              - vaccuum goes all the way downstream the beamline until the GlueX detector.
+          5. Modified the layout of the 1st sweeping magnet:
+              - the outer dimensions are 29.2 x 24.8 x 355.6 cm3
+              - the gap size is 10.22 x 4.9 cm2 
+              - the field inside the gap is 0.23 T (integrated field is 0.82 Tm)
+              - the elliptical vacuum pipe goes through the magnet. The semi-axes of the pipe 
+              are 4.95 cm and 2.29 cm.        
+          6. Added the concrete blocks around the 1st sweeping magnet, composition ConcreteWall1. 
+             The size of the wall is 101.6 x 147.32 x 121.92 cm3.
+          7. Added the composition Flange2 to connect the 1st sweeping magnet with a vacuum chamber.
+          8. Added a vacuum chamber after the 1st sweeping magnet with the following dimensions:
+              - 50.8 cm long tube with the inner and outer radii of Rin = 9.83 cm and Rout = 9.85.
+          9. Added the small lead wall after the vacuum chamber, composition LeadBand1.
+         10. Added the composition Flange3 to connect the vacuum pipe between the lead band and the
+             2nd collimatoor.
+         11. Changed material of the 2nd collimator from Nickel to Iron. The default pinhole 
+             diameter was changed from 1 cm to 0.6 cm.
+         12. Added the composition Flange4 to connect the vacuum pipe between the 2nd collimator and
+             the 2nd sweeping magnet.
+         13. Changed the layout of the second sweeping magnet:
+              - outer dimensions are 42 x 20.8 cm2
+              - the gap size is 20.3 x 5 cm2, the field in the gap is 0.23 T
+              - 1.75 cm radius vacuum beam pipe goes through the magnet.         
+         14. Added the composition Flange5 to connect 2nd the sweeping magnet with the vacuum beam 
+             pipe.           
+         15. Added a 1m long vacuum beam pipe. The inner and outer radii are 2.38 and 2.54 cm, 
+             respectively.
+         16. Added the small lead wall (composition LeadBand2), 81.28 x 20.32 x 10.16 cm3.
+         17. Placed the vertical plane DET2 after the lead wall. 
+         18. Added the composition Flange6 to connect the vacuum pipe between the lead wall and 
+             a pair spectrometer converter box.          
+         19. Added the pair spectrometer converter. The converter thickness and material can be set
+             in the box 'PTAR'   <box  name="PTAR" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />.
+         20. Added the composition Flange7 to connect the vacuum pipe between the converter and 
+             the concrete wall.
+         21. Modified the size of the concrete shielding wall to 450.0 x 270.0 x 121.92 cm3.
+             Added passage to the collimator cave.
+         22. Decreased thickness of the lead wall to 5.08 cm (size of the lead brick).
+              
+     Revision 2.2  12/22/2008
+       Modified the composition 'beamPipe'. Now 'beamPipe' extends the vacuum from the 
+       pair spectrometer to the position of the target.
+
+     Revision 3.0  3/2/2011
+       Large group of revisions, to reflect the beamline geometry and shielding
+       in the engineering drawings for the cave, and the new pair spectrometer.
+
+     Revision 3.1 9/6/2013
+       Updates for compatibility with geant4 -rtj
+       a) Many small shifts to various volumes to eliminate overlaps.
+       b) Changes to dimensions of the active collimator wedges, and even
+          the number of pins per row, so that all overlaps are eliminated.
+
+     Revision 3.2 12/12/2016
+       Updates to introduce the triplet polarimeter -rtj
+       a) renamed downstream PS converter target from PTAR to CONV
+       b) reserved the name PTAR for the triplet polarimeter target
+       c) incorporated a detailed geometric model of the triplet polarimeter
+          from the ASU group into the beamline geometry
+
+     Revision 3.3 3/27/2017
+     Added TAC and some material downstream the FCAL - A.S. 
+     - FCAL dark box window, FCAL platform pipe with plexiglass window, beam 
+     - intensity monitor, and TAC
+
+
+
+<HDDS specification="v1.0" xmlns="http://www.gluex.org/hdds">
+-->
+
+<section name        = "BeamLine"
+         version     = "3.2"
+         date        = "2016-12-12"
+         author      = "R.T. Jones"
+         top_volume  = "collimatorPackage"
+         specification = "v1.0">
+
+<!-- Origin of collimatorPackage is center of the entrance face of the
+     primary collimator.  					-->
+
+  <composition name="collimatorPackage">
+    <posXYZ volume="ShieldedCollimator" X_Y_Z="0.0  0.0  400.0" />
+  </composition>
+
+  <box name="SHLD" X_Y_Z="550.  550.  1300." material="Concrete"/>
+  <composition name="ShieldedCollimator" envelope="SHLD">
+    <posXYZ volume="pipeFromTaggerHall" X_Y_Z="0.0  0.0  -625.0" />
+    <posXYZ volume="collimatorCave" X_Y_Z="0.0  35.0  25.0" />
+  </composition>  
+ 
+  <box  name="CAVE" X_Y_Z="450. 270. 1250." material="Air" />
+  <composition name="collimatorCave" envelope="CAVE">
+    <posXYZ volume="collimatorStack" X_Y_Z="0.0 -35.0 -500.0"/>     
+<!--  <posXYZ volume="DET2" X_Y_Z="0.0  0.0  225.0" /> -->
+    <posXYZ volume="DET3" X_Y_Z="0.0  132.0  0.0" />
+  </composition>
+ 
+  <composition name="collimatorSubCave">
+    <posXYZ volume="collimatorStack" />
+  </composition>
+
+  <composition name="collimatorStack">
+    <posXYZ volume="BeamPipe0"     X_Y_Z="0.0  0.0  -125.0"  />
+    <!--posXYZ volume="PFLD"          X_Y_Z="0.0  0.0  -99.0"  />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -97.0"   />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -93.0"   /-->
+    <posXYZ volume="DET1"          X_Y_Z="0.0  0.0  -49.46"  />
+    <posXYZ volume="ColDetector"   X_Y_Z="0.0  0.0  -46.16"  />
+    <posXYZ volume="PrimaryCol"    X_Y_Z="0.0  0.0  -33.96"  />
+    <posXYZ volume="Flange1"       X_Y_Z="0.0  0.0   11.52"  />
+    <posXYZ volume="sweepMagnet1"  X_Y_Z="0.0  0.0   189.32" />
+    <posXYZ volume="ConcreteWall1" X_Y_Z="0.0  0.0   107.96" />
+    <posXYZ volume="Flange2"       X_Y_Z="0.0  0.0   367.12" />
+    <posXYZ volume="VacuumChamber" X_Y_Z="0.0  0.0   426.54" />
+    <posXYZ volume="LeadBand1"     X_Y_Z="0.0  0.0   457.02" />
+    <posXYZ volume="Flange3"       X_Y_Z="0.0  0.0   462.10" />
+    <posXYZ volume="COL2"          X_Y_Z="0.0  0.0   555.04" />
+    <posXYZ volume="Flange4"       X_Y_Z="0.0  0.0   580.44" />
+    <posXYZ volume="sweepMagnet2"  X_Y_Z="0.0  0.0   630.28" />
+    <posXYZ volume="Flange5"       X_Y_Z="0.0  0.0   648.28" />
+    <posXYZ volume="BeamPipe1"     X_Y_Z="0.0  0.0   712.28" />
+    <posXYZ volume="LeadBand2"     X_Y_Z="0.0  0.0   743.52" />
+    <posXYZ volume="DET2"          X_Y_Z="0.0  35.0  748.65" /> 
+    <posXYZ volume="Flange6"       X_Y_Z="0.0  0.0   748.70" />
+    <posXYZ volume="TripletPolar"  X_Y_Z="0.0 0.0    820.00" />
+    <posXYZ volume="Flange7"       X_Y_Z="0.0  0.0   840.954" />
+    <posXYZ volume="ConcreteWall2" X_Y_Z="0.0  33.0  941.24" />
+    <posXYZ volume="shieldingWall" X_Y_Z="0.0  35.0 1004.74" />     
+    <!--    <posXYZ volume="TargetBox"     X_Y_Z="0.0  0.0 1085.00" />   -->
+    <posXYZ volume="BeamPipe2"     X_Y_Z="0.0  0.0  1066.668" /> 
+  </composition>
+  
+<!-- Beam Pipe 0 -->
+
+  <composition name="pipeFromTaggerHall" envelope="PFTH">
+    <posXYZ volume="PFTV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PFTH" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="PFTV" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipe0">
+    <posXYZ volume="BeamPipeTube"    X_Y_Z="0.0  0.0  25.0" />
+    <posXYZ volume="BeamPipeFlange1" X_Y_Z="0.0  0.0  48.58" />
+    <posXYZ volume="BeamPipeExitWindow" X_Y_Z="0.0  0.0  50.0" />
+    <posXYZ volume="BeamPipeFlange2" X_Y_Z="0.0  0.0  51.42"  />
+  </composition>
+
+  <composition name="BeamPipeTube" envelope="BPTO">
+    <posXYZ volume="BPTI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPTO" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="BPTI" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipeFlange1">
+    <posXYZ volume="BFO1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BFO1" Rio_Z="12.7   15.24  2.84" material="Iron" />
+
+  <composition name="BeamPipeExitWindow">
+    <posXYZ volume="FCAP" X_Y_Z="0.0  0.0  0.0125"/>
+  </composition>
+
+  <tubs name="FCAP" Rio_Z="0.0   10.16   0.025" material="Kapton" />
+
+  <composition name="BeamPipeFlange2">
+    <posXYZ volume="BFO2" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="BFO2" Rio_Z="10.16   15.24   2.84"  material="Iron" />
+
+
+<!-- Primary Collimator -->
+
+  <composition name="PrimaryCol" envelope="PCPB">
+    <posXYZ volume="TungstenInsert" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="PCPB"  X_Y_Z="30.48  30.48  20." material="Lead" />
+
+  <composition name="TungstenInsert" envelope="PCTT">
+    <posXYZ volume="PCTH" X_Y_Z="0.0 0.0 0.0" />
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.02865 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.05730 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.11459 0 0" /-->
+  </composition>
+  <composition name="PrimaryCollimatorAperture" envelope="PCTH">
+    <posXYZ volume="PCTI" X_Y_Z="0.0 0.0 -5.0" />
+  </composition>
+
+  <box  name="PCTT"  X_Y_Z="5.08   5.08   20." material="Tungsten" />
+  <!--tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" /-->
+  <tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" />
+  <tubs name="PCTI"  Rio_Z="0.05   0.25   10." material="Tungsten" 
+        comment="pin-hole insert for reduced intensity running" />
+
+
+<!-- Flange 1 -->
+
+  <composition name="Flange1">
+    <posXYZ volume="FlangeOneDisk" X_Y_Z="0.0  0.0  -7.72" />
+    <posXYZ volume="FlangeOneWindow" X_Y_Z="0.0  0.0  -6.65" />
+    <posXYZ volume="FlangeOnePipe" X_Y_Z="0.0  0.0  -3.325" />
+  </composition>
+
+  <composition name="FlangeOneDisk">
+    <posXYZ volume="FOI1" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="FOI1" Rio_Z="1.27  8.57  2.14"  material="Iron" />
+
+  <composition name="FlangeOneWindow">
+    <posXYZ volume="F1CP" X_Y_Z="0.0  0.0  -0.0075"/>
+  </composition>
+
+  <tubs name="F1CP" Rio_Z="0.0   1.27  0.015" material="Kapton" />
+
+  <composition name="FlangeOnePipe" envelope="FOPO">
+    <posXYZ volume="FOPI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FOPO" Rxy_Z="5.11  2.45   6.65" material="Iron" />
+  <eltu name="FOPI" Rxy_Z="4.95  2.29   6.65" material="Vacuum" />
+
+
+<!-- 1st Sweeping Magnet -->
+
+  <composition name="sweepMagnet1" envelope="MAG1">
+    <posXYZ volume="POL1" X_Y_Z="0.0 +7.425 0.0" />
+    <posXYZ volume="POL1" X_Y_Z="0.0 -7.425 0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="-9.855 0.0  0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="+9.855 0.0  0.0" />
+    <posXYZ volume="MagnetPipe1" X_Y_Z="0.0  0.0  0.0" />
+  </composition> 
+
+  <box name="MAG1" X_Y_Z="29.2 24.8 355.6" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <box name="POL1" X_Y_Z="29.2  9.95  355.6" material="Iron" />
+  <box name="GAP1" X_Y_Z="9.49  4.9   355.6" material="Iron" />
+
+  <composition name="MagnetPipe1" envelope="MPO1">
+    <posXYZ volume="MPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="MPO1" Rxy_Z="5.11  2.45  355.6" material="Iron" />
+  <eltu name="MPI1" Rxy_Z="4.95  2.29  355.6" material="Vacuum" />
+
+
+<!-- Concrete Wall around the 1st sweeping magnet -->
+
+  <composition name="ConcreteWall1">
+    <posXYZ volume="WTOP" X_Y_Z="0.0   +30.3  0.0" />
+    <posXYZ volume="WBOT" X_Y_Z="0.0   -56.2  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="+32.7   0.0  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="-32.7   0.0  0.0" />
+  </composition> 
+
+  <box name="WTOP" X_Y_Z="101.6  35.8  121.92" material="Concrete" />
+  <box name="WBOT" X_Y_Z="101.6  87.6  121.92" material="Concrete" />
+  <box name="WSID" X_Y_Z="36.2   24.8  121.92" material="Concrete" />
+
+
+<!-- Flange 2 -->
+
+  <composition name="Flange2">
+    <posXYZ volume="FlangeTwoDisk1" X_Y_Z="0.0  0.0  2.29" />
+    <posXYZ volume="FlangeTwoDisk2" X_Y_Z="0.0  0.0  6.72"/>
+    <posXYZ volume="FlangeTwoDisk3" X_Y_Z="0.0  0.0  16.88"/>
+    <posXYZ volume="FlangeTwoDisk4" X_Y_Z="0.0  0.0  27.04"/>
+    <posXYZ volume="FlangeTwoDisk5" X_Y_Z="0.0  0.0  31.6"/>
+  </composition>
+
+  <composition name="FlangeTwoDisk1" envelope="FTO1">
+    <posXYZ volume="FTI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FTO1" Rxy_Z="5.11  2.45   4.58" material="Iron" />
+  <eltu name="FTI1" Rxy_Z="4.95  2.29   4.58" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk2" envelope="FTO2">
+    <posXYZ volume="FTI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO2" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI2" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk3" envelope="FTO3">
+    <posXYZ volume="FTI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO3" Rio_Z="0.0  6.21  16.04" material="Iron" />   
+  <tubs name="FTI3" Rio_Z="0.0  6.19  16.04" material="Vacuum" /> 
+
+  <composition name="FlangeTwoDisk4" envelope="FTO4">
+    <posXYZ volume="FTI4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO4" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI4" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk5" envelope="FTO5">
+    <posXYZ volume="FTI5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO5" Rio_Z="0.0  6.35   4.84" material="Iron" />
+  <tubs name="FTI5" Rio_Z="0.0  6.19   4.84" material="Vacuum" />
+
+
+<!-- Vacuum chamber after the 1st sweeping magnet-->
+
+  <composition name="VacuumChamber">
+    <posXYZ volume="VacuumChambDisk1" X_Y_Z="0.0 0.0 -25.30"/>
+    <posXYZ volume="VacuumChambDisk2" X_Y_Z="0.0 0.0  0.0"/>
+    <posXYZ volume="VacuumChambDisk3" X_Y_Z="0.0 0.0  25.30"/>
+  </composition>
+
+  <composition name="VacuumChambDisk1" envelope="VCO1">
+    <posXYZ volume="VCI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO1" Rio_Z="0.0  9.85   0.2" material="Iron" />
+  <tubs name="VCI1" Rio_Z="0.0  6.19   0.2" material="Vacuum" />
+
+  <composition name="VacuumChambDisk2" envelope="VCO2">
+    <posXYZ volume="VCI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO2" Rio_Z="0.0  9.85  50.40" material="Iron" />
+  <tubs name="VCI2" Rio_Z="0.0  9.83  50.40" material="Vacuum" />
+
+  <composition name="VacuumChambDisk3" envelope="VCO3">
+    <posXYZ volume="VCI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO3" Rio_Z="0.0  9.85  0.2" material="Iron" />
+  <tubs name="VCI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+
+<!-- Lead Band 1 -->
+
+  <composition name="LeadBand1" envelope="LBD1">
+    <posXYZ volume="LeadBandPipe1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe1" envelope="LBO1">
+    <posXYZ volume="LBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD1" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO1" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI1" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 3 -->
+
+  <composition name="Flange3">
+    <posXYZ volume="FlangeThreeDisk1" X_Y_Z="0.0  0.0  24.56" />
+    <posXYZ volume="FlangeThreeDisk2" X_Y_Z="0.0  0.0  50.70"/>
+    <posXYZ volume="FlangeThreeDisk3" X_Y_Z="0.0  0.0  55.78"/>
+    <posXYZ volume="FlangeThreeDisk4" X_Y_Z="0.0  0.0  60.86"/>
+    <posXYZ volume="FlangeThreeDisk5" X_Y_Z="0.0  0.0  64.99"/>
+  </composition>
+
+  <composition name="FlangeThreeDisk1" envelope="F3O1">
+    <posXYZ volume="F3I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O1" Rio_Z="0.0  2.54  49.12" material="Iron" />
+  <tubs name="F3I1" Rio_Z="0.0  2.38  49.12" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk2" envelope="F3O2">
+    <posXYZ volume="F3I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk3" envelope="F3O3">
+    <posXYZ volume="F3I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F3I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk4" envelope="F3O4">
+    <posXYZ volume="F3I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk5" envelope="F3O5">
+    <posXYZ volume="F3I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O5" Rio_Z="0.0  2.54   5.1" material="Iron" />
+  <tubs name="F3I5" Rio_Z="0.0  2.38   5.1" material="Vacuum" />
+
+
+<!-- 2nd Collimator -->
+
+  <composition name="COL2" envelope="OCOL">
+    <posXYZ volume="ICOL" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="OCOL" Rio_Z="0.0  10.0  50.8" material="Iron" />
+  <tubs name="ICOL" Rio_Z="0.0   0.5  50.8" material="Vacuum" />
+
+<!-- Flange 4 -->
+
+  <composition name="Flange4">
+    <posXYZ volume="FlangeFourDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFourDisk2" X_Y_Z="0.0  0.0  9.84"/>
+    <posXYZ volume="FlangeFourDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFourDisk4" X_Y_Z="0.0  0.0  20.0"/>
+    <posXYZ volume="FlangeFourDisk5" X_Y_Z="0.0  0.0  26.71"/>
+  </composition>
+
+  <composition name="FlangeFourDisk1" envelope="F4O1">
+    <posXYZ volume="F4I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F4I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+
+  <composition name="FlangeFourDisk2" envelope="F4O2">
+    <posXYZ volume="F4I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk3" envelope="F4O3">
+    <posXYZ volume="F4I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F4I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFourDisk4" envelope="F4O4">
+    <posXYZ volume="F4I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I4" Rio_Z="0.0  1.745  3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk5" envelope="F4O5">
+    <posXYZ volume="F4I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O5" Rio_Z="0.0  1.905   10.26" material="Iron" />
+  <tubs name="F4I5" Rio_Z="0.0  1.745   10.26" material="Vacuum" />
+
+
+<!-- 2nd Sweeping Magnet -->
+
+  <composition name="sweepMagnet2">
+    <posXYZ volume="Core" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Core" envelope="POL2">
+    <posXYZ volume="Aperture" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Aperture" envelope="GAP2">
+    <posXYZ volume="MagnetPipe2" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="POL2" X_Y_Z="42.0  20.8  36.0" material="Iron" />
+  <box name="GAP2" X_Y_Z="20.3   5.0  36.0" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <composition name="MagnetPipe2" envelope="MPO2">
+    <posXYZ volume="MPI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="MPO2" Rio_Z="0.0  1.905  36.0" material="Iron" />
+  <tubs name="MPI2" Rio_Z="0.0  1.745  36.0" material="Vacuum" />
+
+
+<!-- Flange 5 -->
+
+  <composition name="Flange5">
+    <posXYZ volume="FlangeFiveDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFiveDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeFiveDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFiveDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeFiveDisk5" X_Y_Z="0.0  0.0  29.71"/>
+  </composition>
+
+  <composition name="FlangeFiveDisk1" envelope="F5O1">
+    <posXYZ volume="F5I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O1" Rio_Z="0.0  1.905  8.26" material="Iron" />
+  <tubs name="F5I1" Rio_Z="0.0  1.745  8.26" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk2" envelope="F5O2">
+    <posXYZ volume="F5I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk3" envelope="F5O3">
+    <posXYZ volume="F5I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F5I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk4" envelope="F5O4">
+    <posXYZ volume="F5I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk5" envelope="F5O5">
+    <posXYZ volume="F5I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O5" Rio_Z="0.0  2.54  16.26" material="Iron" />
+  <tubs name="F5I5" Rio_Z="0.0  2.38  16.26" material="Vacuum" />
+
+
+<!-- Beam Pipe1 -->
+
+  <composition name="BeamPipe1" envelope="BPO1">
+    <posXYZ volume="BPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPO1" Rio_Z="0.0  2.54  52.32" material="Iron" />
+  <tubs name="BPI1" Rio_Z="0.0  2.38  52.32" material="Vacuum" />
+
+<!-- Lead Band 2 -->
+
+  <composition name="LeadBand2" envelope="LBD2">
+    <posXYZ volume="LeadBandPipe2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe2" envelope="LBO2">
+    <posXYZ volume="LBI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD2" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO2" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI2" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 6 -->
+
+<!-- Without DET2
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  25.71"/>
+  </composition>
+-->
+
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.08" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.74" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.82"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  19.9" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  35.98"/>
+  </composition>
+
+  <composition name="FlangeSixDisk1" envelope="F6O1">
+    <posXYZ volume="F6I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+<!-- Without DET2
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+-->
+
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.16" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk2" envelope="F6O2">
+    <posXYZ volume="F6I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk3" envelope="F6O3">
+    <posXYZ volume="F6I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F6I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSixDisk4" envelope="F6O4">
+    <posXYZ volume="F6I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk5" envelope="F6O5">
+    <posXYZ volume="F6I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O5" Rio_Z="0.0  2.54   29.0" material="Iron" />
+  <tubs name="F6I5" Rio_Z="0.0  2.38   29.0" material="Vacuum" />
+
+
+  <composition name="TargetBox">
+    <posXYZ volume="TargetBoxDisk1" X_Y_Z="0.0 0.0 -10.9"/>
+    <posXYZ volume="TargetBoxDisk2" X_Y_Z="0.0 0.0  0.0" />
+    <posXYZ volume="TargetBoxDisk3" X_Y_Z="0.0 0.0  10.9"/>
+  </composition>
+
+  <composition name="TargetBoxDisk1" envelope="TBO1">
+    <posXYZ volume="TBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO1" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI1" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+  <composition name="TargetBoxDisk2" envelope="TBO2">
+    <posXYZ volume="TargetInnerBox" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="TargetInnerBox" envelope="TBI2">
+    <posXYZ volume="CONV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO2" X_Y_Z="22.0  20.0  21.6" material="Iron" />
+  <box name="TBI2" X_Y_Z="21.6  19.6  21.6" material="Vacuum" />
+
+  <composition name="TargetBoxDisk3" envelope="TBO3">
+    <posXYZ volume="TBI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO3" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+  <box  name="CONV" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />
+
+
+
+
+
+
+<!-- Flange 7 -->
+
+  <composition name="Flange7">
+    <posXYZ volume="FlangeSevenDisk1" X_Y_Z="0.0  0.0  8.8721" />
+    <posXYZ volume="FlangeSevenDisk2" X_Y_Z="0.0  0.0  19.3224" />
+    <posXYZ volume="FlangeSevenDisk3" X_Y_Z="0.0  0.0  24.4024" />
+    <posXYZ volume="FlangeSevenDisk4" X_Y_Z="0.0  0.0  29.4824" />
+    <posXYZ volume="FlangeSevenDisk5" X_Y_Z="0.0  0.0  35.1924" />
+  </composition>
+
+  <composition name="FlangeSevenDisk1" envelope="F7O1">
+    <posXYZ volume="F7I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O1" Rio_Z="0.0  2.54  17.7424" material="Iron" />
+  <tubs name="F7I1" Rio_Z="0.0  2.38  17.7424" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk2" envelope="F7O2">
+    <posXYZ volume="F7I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk3" envelope="F7O3">
+    <posXYZ volume="F7I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F7I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk4" envelope="F7O4">
+    <posXYZ volume="F7I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk5" envelope="F7O5">
+    <posXYZ volume="F7I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O5" Rio_Z="0.0  2.54   8.26" material="Iron" />
+  <tubs name="F7I5" Rio_Z="0.0  2.38   8.26" material="Vacuum" />
+
+
+<!-- Concrete Wall -->
+
+  <composition name="ConcreteWall2" envelope="BLC2">
+    <posXYZ volume="ENTR" X_Y_Z="-179.0  0.0 -30.46"/>
+    <posXYZ volume="Block2Hole" X_Y_Z="0.0 -33.0 0.0"/>
+  </composition>
+
+  <box name="ENTR" X_Y_Z="92.0 266.0 61.0" material="Air" />
+
+  <composition name="Block2Hole" envelope="OBHO">
+    <posXYZ volume="IBHO"  X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="BLC2" X_Y_Z="450.0 266.0 121.92" material="Concrete" />
+  <tubs name="OBHO" Rio_Z="0.0  2.54  121.92" material="Iron" />
+  <tubs name="IBHO" Rio_Z="0.0  2.38  121.92" material="Vacuum" />
+
+
+<!-- Lead Wall -->
+
+  <composition name="shieldingWall" envelope="WALL">
+    <posXYZ volume="WallHole" X_Y_Z="0.0  -35.0  0.0"/>
+  </composition>
+
+  <box name="WALL" X_Y_Z="450. 270. 5.08" material="Lead" />
+
+  <composition name="WallHole" envelope="OWHO">
+    <posXYZ volume="IWHO" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="OWHO" Rio_Z="0.0  2.54 5.08" material="Iron" />
+  <tubs name="IWHO" Rio_Z="0.0  2.38 5.08" material="Vacuum" />
+
+
+<!-- Beam Pipe2 -->
+
+  <composition name="BeamPipe2" envelope="BPO2">
+  <!-- MUST COMMENT OUt either one or the other of the two lines below -->
+    <!-- <posXYZ volume="BeamPipe2Inner" /> enables the photon beam harp -->
+    <posXYZ volume="BPI2" /> <!-- disables the photon beam harp -->
+  </composition>
+  
+  <composition name="BeamPipe2Inner" envelope="BPI2">
+    <posXYZ volume="photonBeamHarp" X_Y_Z="0.0 0.0 -27.38" />
+  </composition>
+  
+  <composition name="photonBeamHarp">
+    <posXYZ volume="PSCV" />
+    <posXYZ volume="PSCH" />
+  </composition>
+
+  <tubs name="BPO2" Rio_Z="0.0  2.54   118.767" material="Iron" />
+  <tubs name="BPI2" Rio_Z="0.0  2.38   118.767" material="Vacuum" />
+    
+  <composition name="PairSpecConverter" envelope="PSCM">
+    <posXYZ volume="PSCV"/>
+    <posXYZ volume="PSCH"/>
+  </composition>
+  
+  <tubs name="PSCM" Rio_Z="0.0 2.38 0.53" material="Vacuum"/>
+  <tubs name="PSCV" Rio_Z="0.0 1.143 0.01" material="Aluminum"/>
+  <tubs name="PSCH" Rio_Z="1.143 2.38 0.53" material="Iron"/>
+
+  <tubs name="DET1" Rio_Z="0.   50.  2." material="Air" />
+  <box name="DET2" X_Y_Z=" 450. 270. 0.1" material="Vacuum" />
+  <box name="DET3" X_Y_Z=" 450. 2. 918." material="Air" />
+
+  
+<!-- The composition 'beamPipe' extends the vacuum from the pair 
+     spectrometer to the position of the target.
+
+     Origin of beamPipe is center of the hall.
+-->
+
+  <composition name="beamPipe">
+<!--    <posXYZ volume="DET4"     X_Y_Z="  0.0     0.0 -1400.0"/> -->
+    <posXYZ volume="DET5"     X_Y_Z="  0.0     0.0  1400.0"/> 
+    <posXYZ volume="TAC1" X_Y_Z="150.0  -350.0  1225.0" />  
+    <posXYZ volume="DarkWindow" X_Y_Z="  150.0  -350.0  320.0" />
+    <posXYZ volume="PlatformPipe" X_Y_Z="150.0  -350.0  650."/>
+    <posXYZ volume="PlexWindow" X_Y_Z="150.0  -350.0  830."/>
+    <posXYZ volume="IntMonitor" X_Y_Z="150.0  -350.0  834."/>
+    <posXYZ volume="DET6"     X_Y_Z="  0.0   600.0     0.0"/>
+    <!--posXYZ volume="DET7"     X_Y_Z="  0.0     0.0  -705.0"/--> 
+    <posXYZ volume="HallBellows" X_Y_Z="150.0 -350.0 -1223.287"/>
+    <posXYZ volume="HallPipe" X_Y_Z="150.0  -350.0  -1026.77"/>
+    <!-- Plastic scintillator for beam diagonistics -->
+    <!--posXYZ volume="DET8" X_Y_Z="150 -350.0 -834.0 "/-->
+  </composition>
+
+  <composition name="DarkWindow">
+    <posXYZ volume="DBOW" X_Y_Z="  0.0  0.0  0.0" />
+    <posXYZ volume="DBEW" X_Y_Z="  0.0  0.0  0.0" />
+  </composition>
+
+  <tubs name="DBOW" Rio_Z="20.0  60.0  0.3"  material="Aluminum"/>
+  <tubs name="DBEW" Rio_Z="0.0   20.0  0.01" material="Tedlar"/>
+
+  <composition name="PlatformPipe">
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0  -176.5127" />
+    <posXYZ volume="PipeSection" X_Y_Z="0.0 0.0 0.0" />
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0   176.5127" />
+  </composition>
+
+  <tubs name="PPWD" Rio_Z="0.0   20.32  0.0254" material="Kapton" />
+
+  <composition name="PipeSection" envelope="PPOV">
+    <posXYZ volume="PPIV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PPOV" Rio_Z="0.0   20.32  353.0" material="Iron" />
+  <tubs name="PPIV" Rio_Z="0.0   20.04  353.0" material="Vacuum" />
+
+  <composition name="PlexWindow">
+    <posXYZ volume="PPPW" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="IntMonitor" >
+    <posXYZ volume="INTM" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box  name="INTM" X_Y_Z="2  6  1" material="Scintillator"  />
+
+  <tubs name="PPPW" Rio_Z="0.0   20.32  0.3" material="Plexiglas" />
+
+  <box  name="TAC1" X_Y_Z="20  20  45" material="leadGlassF800" sensitive="true" />
+
+
+  <box name="DET4" X_Y_Z="1700.0  1200.0  2.0" material="Vacuum" />
+  <box name="DET5" X_Y_Z="1700.0  1198.0  2.0" material="Air" />
+  <box name="DET6" X_Y_Z="1700.0  2.0  3000.0" material="Air" />
+  <!--box name="DET7" X_Y_Z="1700.0  1198.0  2.0" material="Air" /-->
+  <tubs name="DET7" Rio_Z="0.0 1.7399  2.0" material="Vacuum"
+        comment="disk detector inside beam pipe at target entrance" />
+  <box name="DET8" X_Y_Z="10.0 10.0 1.0" material="Scintillator" sensitive="true"/>
+
+<!-- Hall bellows -->
+<composition name="HallBellows" envelope="BLWO">
+  <posXYZ volume="BLWI" X_Y_Z="0.0 0.0 -3.5011"/>
+</composition>
+
+<pcon name="BLWO" material="Iron">
+  <polyplane Rio_Z="0.0 1.90500 -13.4"/>
+  <polyplane Rio_Z="0.0 1.90500 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 6.3978"/>
+</pcon>
+
+<tubs name="BLWI" Rio_Z="0. 1.7399 19.7978" material="Vacuum"/>
+
+<!-- Hall Pipe -->
+  <composition name="HallPipe" envelope="OHPI" >
+    <!--posXYZ volume="IHPI" X_Y_Z="0 0 98.6305"/-->
+    <posXYZ volume="InnerHallPipe" X_Y_Z="0.0 0.0 98.6305"/> 
+  </composition>
+
+  <composition name="InnerHallPipe" envelope="IHPI">
+    <posXYZ volume="DET7" X_Y_Z="0 0 280.0"/> 
+    <!--posXYZ volume="CAP1" X_Y_Z="0.0  0.0  190.11265" /-->
+  </composition>
+
+
+  <pcon name="OHPI" material="Iron">
+    <polyplane Rio_Z="0.0 4.27355 -190.1190"/>
+    <polyplane Rio_Z="0.0 4.27355 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +387.380"/>
+  </pcon>
+
+  <tubs name="IHPI" Rio_Z="0.0  1.7399 577.499" material="Vacuum" />
+  <tubs name="CAP1" Rio_Z="0.0  1.7399 0.0127" material="Kapton"/>
+
+<composition name="SixWayCross" envelope="SWCM">
+  <posXYZ volume="sixWayTube" X_Y_Z="0 0 0"/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0 0." rot="0. 180. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 90. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 270. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="90. 0. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="270. 0. 0."/>
+  <posXYZ volume="sixWayBox" X_Y_Z="0. 0. 0."/> 
+</composition>
+
+<box name="SWCM" X_Y_Z="67.9196 67.9196 67.9196" material="Air"
+     comment="Six-way cross mother volume"/>
+<pcon name="SWCP" material="StainlessSteel" comment="Vacuum pipe for 6-way cross">
+  <polyplane Rio_Z="0. 20.32 20.32"/>
+  <polyplane Rio_Z="0. 20.32 32.258"/>
+  <polyplane Rio_Z="0. 22.504 32.258"/>
+  <polyplane Rio_Z="0. 22.504 33.9598"/>
+</pcon>
+  
+<composition name="sixWayTube" envelope="SWCP">
+  <posXYZ volume="SWC2" X_Y_Z="0.0 0.0 27.1399"/>
+</composition>
+
+<composition name="sixWayBox" envelope="SWCB">
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 -20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 -20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="20.08125 0. 0." rot="0 90 0 "/>
+  <posXYZ volume="SWC1" X_Y_Z="-20.08125 0. 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeMotherVolume" X_Y_Z="0. 0. 0." />
+</composition>
+
+<composition name="coldCubeMotherVolume" envelope="CBXM">
+  <posXYZ volume="CBX1" X_Y_Z="0. -7.712  0."/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.1444"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.3032"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 -12.1444"/>
+  <posXYZ volume="CBXS" X_Y_Z="12.1444 4.28 0."/>
+  <posXYZ volume="CBXS" X_Y_Z="-12.1444 4.28 0."/>
+  <posXYZ volume="coldCubeTopPlate" X_Y_Z="0. 16.272 0." rot="90 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 -11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="11.9856 4.28 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="-11.9856 4.28 0." rot="0 90 0"/>
+</composition>
+
+<composition name="coldCubeBeamPlate" envelope="CBXB">
+  <posXYZ volume="CBH0" X_Y_Z="0. -4.2926 0."/>
+</composition>
+
+<composition name="coldCubeSidePlate" envelope="CBSP">
+  <posXYZ volume="CBH2" X_Y_Z="0. 0. 0."/>
+</composition>
+
+<composition name="coldCubeTopPlate" envelope="CHXT">
+  <posXYZ volume="CBH1" X_Y_Z="0. 0. 0." />
+</composition>
+
+<box name="CBSP" X_Y_Z="23.8124 23.8124 0.15875" material="Copper"/>
+<box name="CHXT" X_Y_Z="24.13 24.13 0.15875" material="Copper"/>
+<tubs name="CBH1" Rio_Z="0. 10.795 0.15875" material="Vacuum"/>
+<tubs name="CBH0" Rio_Z="0 1.27 0.15875" material="Vacuum" 
+      comment="Hole for beam"/>
+<box name="CBH2" X_Y_Z="19.05 19.05 0.15875" material="Vacuum"/>
+<box name="CBXB" X_Y_Z="21.8948 21.8948 0.15875" material="Copper"/>
+<box name="CBXS" X_Y_Z="0.15875 21.8948 21.8948" material="Copper"/>
+<box name="CBX1" X_Y_Z="24.13 0.15875 24.13" material="Copper"/>
+<box name="CBXM" X_Y_Z="39.685 39.685 39.685" material="Vacuum"/>
+<box name="SWCB" X_Y_Z="40.64 40.64 40.64" material="StainlessSteel"/>
+<tubs name="SWC1" Rio_Z="0 19.84248 0.4775" material="Vacuum"/>
+<tubs name="SWC2" Rio_Z="0. 19.84248 13.6398" material="Vacuum"/>
+
+<!-- Approximation for the beam profiler -->
+<box name="PFSC" X_Y_Z="12.8 12.8 0.2" material="Scintillator" sensitive="true"/>
+<box name="PFLD" X_Y_Z="10.0 10.0 0.1" material="Lead"/>
+
+<!-- Following is the definition of the active collimator.  It sits
+     on the upstream end of the primary collimator and acts as an
+     active absorber with segmented detection of the beam intensity.
+-->
+
+  <composition name="ColDetector" envelope="INSU">
+    <posXYZ volume="ColAssemblyFinal" X_Y_Z="0.0 0.0 0.50"/>
+    <posXYZ volume="HOUF" X_Y_Z="0.0  0.0  -1.85"/>
+  </composition>
+
+  <composition name="ColAssemblyFinal" envelope="HOUS">
+    <posXYZ volume="ColAssemblyInitial" X_Y_Z="0.0  0.0  -0.15"/>
+  </composition>
+  
+  <composition name="ColAssemblyInitial" envelope="AIRH">
+    <mposPhi volume="DIV1" ncopy="4" Phi0="0" dPhi="90" R_Z="3.375 0."/>  
+    <mposPhi volume="DIV2" ncopy="4" Phi0="45" dPhi="90"/>  
+    <mposPhi volume="innerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+    <mposPhi volume="outerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+  </composition>
+
+  <tubs name="INSU" Rio_Z="0.25   7.36  4.20" material="BoronNitride"/>
+ 
+  <tubs name="HOUS" Rio_Z="0.25   6.70  3.20" material="Aluminum" />
+ 
+  <tubs name="HOUF" Rio_Z="0.25   6.85  0.50" material="Aluminum"/>
+ 
+  <tubs name="AIRH" Rio_Z="0.25   6.5002  2.9" material="Air" />
+  <box  name="DIV1" X_Y_Z="6.25  0.1  2.9" material="Aluminum" />
+  <tubs name="DIV2" Rio_Z="2.7   2.8  2.9" profile="-42.870 85.740"
+                                           material="Aluminum" />
+
+  <composition name="innerPinCushionWedge" envelope="ACWI">
+    <posXYZ volume="ACBI" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="innerPinCushionRow_1" X_Y_Z="0.276 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_2" X_Y_Z="0.376 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_3" X_Y_Z="0.476 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_4" X_Y_Z="0.576 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_5" X_Y_Z="0.676 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_6" X_Y_Z="0.776 0.0 0.40" />
+  </composition>
+  <composition name="innerPinCushionRow_1" envelope="AIR1">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_2" envelope="AIR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_3" envelope="AIR3">
+    <mposY volume="PIN1" ncopy="5" Y0="-0.20" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_4" envelope="AIR4">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_5" envelope="AIR5">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_6" envelope="AIR6">
+    <mposY volume="PIN1" ncopy="9" Y0="-0.40" dY="0.10" />
+  </composition>
+
+  <composition name="outerPinCushionWedge" envelope="ACWO">
+    <posXYZ volume="ACBO" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 -1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 +1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 -1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 +1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 -1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 +1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 -1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 +1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_5" X_Y_Z="3.025 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_6" X_Y_Z="3.125 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_7" X_Y_Z="3.225 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_8" X_Y_Z="3.325 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_9" X_Y_Z="3.425 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_10" X_Y_Z="3.525 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_11" X_Y_Z="3.625 0.0 0.40" />
+  </composition>
+  <composition name="outerPinCushionRow_1" envelope="AOR1">
+    <posXYZ volume="PIN1" />
+  </composition>
+  <composition name="outerPinCushionRow_2" envelope="AOR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_3" envelope="AOR3">
+    <mposY volume="PIN1" ncopy="6" Y0="-0.25" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_4" envelope="AOR4">
+    <mposY volume="PIN1" ncopy="10" Y0="-0.45" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_5" envelope="AOR5">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_6" envelope="AOR6">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_7" envelope="AOR7">
+    <mposY volume="PIN1" ncopy="37" Y0="-1.80" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_8" envelope="AOR8">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_9" envelope="AOR9">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_10" envelope="AORA">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_11" envelope="AORB">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+
+  <tubs name="ACWI" Rio_Z="0.25 2.5  2.5" profile="-33. 66."
+         material="Air" comment="active collimator inner wedge" />  
+  <tubs name="ACWO" Rio_Z="2.97  6.0  2.5" profile="-33. 66."
+         material="Air" comment="active collimator outer wedge" />  
+  <tubs name="ACBI" Rio_Z="0.25 2.5  0.8" profile="-32. 64."
+         material="SoftTungsten" comment="inner wedge base plate" />  
+  <tubs name="ACBO" Rio_Z="3.0  6.0  0.8" profile="-30. 60."
+         material="SoftTungsten" comment="outer wedge base plate" />  
+
+  <box name="AIR1" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AIR2" X_Y_Z="0.051 0.40 1.7" material="Air" />
+  <box name="AIR3" X_Y_Z="0.051 0.50 1.7" material="Air" />
+  <box name="AIR4" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AIR5" X_Y_Z="0.051 0.80 1.7" material="Air" />
+  <box name="AIR6" X_Y_Z="0.051 0.90 1.7" material="Air" />
+
+  <box name="AOR1" X_Y_Z="0.051 0.10 1.7" material="Air" />
+  <box name="AOR2" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AOR3" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AOR4" X_Y_Z="0.051 1.00 1.7" material="Air" />
+  <box name="AOR5" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR6" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR7" X_Y_Z="0.051 3.70 1.7" material="Air" />
+  <box name="AOR8" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AOR9" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AORA" X_Y_Z="0.051 4.10 1.7" material="Air" />
+  <box name="AORB" X_Y_Z="0.051 4.10 1.7" material="Air" />
+
+  <box name="PIN1" X_Y_Z="0.051 0.051 1.7" material="SoftTungsten" />
+ 
+<!-- Following is the definition of the triplet polarimeter.  It sits
+     just before of the shielding wall at the downstream end of the
+     collimator cave, and contains a retractable pair conversion target
+     called PTAR. Forward pairs are detected in the pair spectrometer.
+-->
+
+<!-- Origin of TripletPolar is the beam axis midpoint
+     of the polarimeter vacuum box, as set by the outside walls. -->
+
+  <composition name="TripletPolar">
+     <apply region="nullBfield"/>
+     <posXYZ volume="tripletPolar" X_Y_Z="1.5 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tripletPolar">
+     <posXYZ volume="tpolEnclosure" />
+     <posXYZ volume="tpolVacuumBoxFlange" X_Y_Z="6.50 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTPT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTPM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTIT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTIM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFT" X_Y_Z="0.0 -7.91 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTFM" X_Y_Z="-4.0 4.0 +7.91" unit_length="in" />
+     <posXYZ volume="PTFF" X_Y_Z="-6.910 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 -8.5" unit_length="in" />
+     <posXYZ volume="PTKM" X_Y_Z="-4.0 4.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKF" X_Y_Z="-7.550 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTDR" X_Y_Z="7.25 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tpolVacuumBox" envelope="PTB0">
+     <posXYZ volume="tpolRailGuide" X_Y_Z="0.375 5.131 -3.380" unit_length="in" />
+     <posXYZ volume="tpolTargetCarrier" X_Y_Z="0.25 2.146 -3.380" rot="0 180 0" unit_length="in" />
+     <posXYZ volume="tpolTargetMotor" X_Y_Z="-1.625 4.1449 -1.6284" unit_length="in" />
+     <posXYZ volume="tpolRecoilDetectorCard" X_Y_Z="-1.625 0.0 -2.0" rot="0 0 22.5" unit_length="in" />
+     <posXYZ volume="PTA1" X_Y_Z="-1.625 0.0 -1.9796" unit_length="in" />
+     <posXYZ volume="PTA2" X_Y_Z="-1.625 0.0 -1.9795" unit_length="in" />
+     <posXYZ volume="PTA3" X_Y_Z="-1.625 0.0 -1.9794" unit_length="in" />
+     <posXYZ volume="PTA4" X_Y_Z="-1.625 0.0 -2.0204" unit_length="in" />
+     <!-- <posXYZ volume="PTA5" X_Y_Z="-1.625 0.0 -3.3651" unit_length="in" /> -->
+     <posXYZ volume="PTMP" X_Y_Z="0.0 5.8125 0.0" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 -5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 -4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="-5.125 5.745 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="-4.625 5.5525 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 -2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="0.4872 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="-3.7372 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="0.4872 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="-3.7372 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="0.4872 5.5 -0.6216" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="-3.7372 5.5 -0.6216" unit_length="in" />
+  </composition>
+
+  <composition name="tpolEnclosure" envelope="PTBO">
+     <posXYZ volume="tpolVacuumBox" X_Y_Z="0.125 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH3" X_Y_Z="-4.0 4.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH6" X_Y_Z="0.0 -6.125 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH5" X_Y_Z="-6.125 0.0 -2.0" rot="0 90 0" unit_length="in" />
+  </composition>
+
+  
+  <tubs name="PTAR" Rio_Z="0.0 0.375 0.0075" material="Beryllium" 
+	comment="polarimeter converter target" /> 
+  
+  
+  <box name="PTBO" X_Y_Z="12.5 12.5 12.5" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube1" />
+  <box name="PTB0" X_Y_Z="12.25 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube2" />
+  <box name="PTB1" X_Y_Z="0.5 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box flange subtraction" />
+  <box name="PTB2" X_Y_Z="0.5 15.0 17.0" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box door flange" />
+  <box name="PTB3" X_Y_Z="9.25 0.988 0.625" material="Aluminum" unit_length="in"
+                   comment="polarimeter rail guide" />
+  <box name="PTB4" X_Y_Z="9.25 0.312 0.125" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail gap subtraction" />
+  <box name="PTB5" X_Y_Z="9.25 0.365 0.375" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail box subtraction" />
+  <box name="PTB6" X_Y_Z="42.0 42.0 2.0" material="Iron" unit_length="mm"
+                   comment="polarimeter motor plate" />
+  <box name="PTB7" X_Y_Z="5.25 5.792 0.118" material="Aluminum" unit_length="in"
+                   comment="polarimeter target holder" />
+  <box name="PTB8" X_Y_Z="4.325 4.292 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter target holder subtraction" />
+  <tubs name="PTH0" Rio_Z="0.0 21.0 69.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motor" />
+  <tubs name="PTH1" Rio_Z="0.0 10.5 32.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motion gear" />
+  <tubs name="PTH2" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter beam hole subtraction" />
+  <tubs name="PTH3" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter motor hole subtraction" />
+  <tubs name="PTH4" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter auxilliary hole subtraction" />
+  <tubs name="PTH5" Rio_Z="0.0 1.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter feed hole subtraction" />
+  <tubs name="PTH6" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter turbo pump hole subtraction" />
+  <tubs name="PTH7" Rio_Z="0.0 0.375 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter converter tray subtraction" />
+
+  <composition name="tpolVacuumBoxFlange" envelope="PTB2">
+     <posXYZ volume="PTB1" />
+  </composition>
+  <composition name="tpolRailGuide" envelope="PTB3">
+     <posXYZ volume="PTB4" X_Y_Z="0.0 -0.338 0.0" unit_length="in" />
+     <posXYZ volume="PTB5" />
+  </composition>
+  <composition name="tpolTargetDisk" envelope="PTH7">
+     <posXYZ volume="PTAR" />
+  </composition>
+  <composition name="tpolTargetCarrier" envelope="PTB7">
+     <posXYZ volume="PTB8" X_Y_Z="0.4625 0.75 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="1.875 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="0.625 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="-0.625 -2.146 0.0" unit_length="in" />
+  </composition>
+  <composition name="tpolTargetMotor">
+     <posXYZ volume="PTH0" />
+     <posXYZ volume="PTB6" X_Y_Z="0.0 0.0 -35.5" unit_length="mm" />
+     <posXYZ volume="PTH1" X_Y_Z="0.0 0.0 -52.5" unit_length="mm" />
+  </composition>
+  
+  <composition name="tpolRecoilDetector" envelope="PTDE">
+     <posXYZ volume="tpolRecoilRing1" />
+     <posXYZ volume="tpolRecoilRing2" />
+     <posXYZ volume="tpolRecoilRing3" />
+     <posXYZ volume="tpolRecoilRing4" />
+     <posXYZ volume="tpolRecoilRing5" />
+     <posXYZ volume="tpolRecoilRing6" />
+     <posXYZ volume="tpolRecoilRing7" />
+     <posXYZ volume="tpolRecoilRing8" />
+     <posXYZ volume="tpolRecoilRing9" />
+     <posXYZ volume="tpolRecoilRing10" />
+     <posXYZ volume="tpolRecoilRing11" />
+     <posXYZ volume="tpolRecoilRing12" />
+     <posXYZ volume="tpolRecoilRing13" />
+     <posXYZ volume="tpolRecoilRing14" />
+     <posXYZ volume="tpolRecoilRing15" />
+     <posXYZ volume="tpolRecoilRing16" />
+     <posXYZ volume="tpolRecoilRing17" />
+     <posXYZ volume="tpolRecoilRing18" />
+     <posXYZ volume="tpolRecoilRing19" />
+     <posXYZ volume="tpolRecoilRing20" />
+     <posXYZ volume="tpolRecoilRing21" />
+     <posXYZ volume="tpolRecoilRing22" />
+     <posXYZ volume="tpolRecoilRing23" />
+     <posXYZ volume="tpolRecoilRing24" />
+  </composition>
+  <tubs name="PTDE" Rio_Z="11.0 35.0 1.5" material="Vacuum" unit_length="mm" 
+                   comment="container for the triplet polarimeter detector" />
+
+  <composition name="tpolRecoilRing1" envelope="PTRA">
+     <mposPhi volume="PTSA" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="1" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing2" envelope="PTRB">
+     <mposPhi volume="PTSB" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="2" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing3" envelope="PTRC">
+     <mposPhi volume="PTSC" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="3" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing4" envelope="PTRD">
+     <mposPhi volume="PTSD" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="4" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing5" envelope="PTRE">
+     <mposPhi volume="PTSE" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="5" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing6" envelope="PTRF">
+     <mposPhi volume="PTSF" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="6" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing7" envelope="PTRG">
+     <mposPhi volume="PTSG" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="7" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing8" envelope="PTRH">
+     <mposPhi volume="PTSH" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="8" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing9" envelope="PTRI">
+     <mposPhi volume="PTSI" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="9" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing10" envelope="PTRJ">
+     <mposPhi volume="PTSJ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="10" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing11" envelope="PTRK">
+     <mposPhi volume="PTSK" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="11" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing12" envelope="PTRL">
+     <mposPhi volume="PTSL" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="12" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing13" envelope="PTRM">
+     <mposPhi volume="PTSM" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="13" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing14" envelope="PTRN">
+     <mposPhi volume="PTSN" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="14" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing15" envelope="PTRO">
+     <mposPhi volume="PTSO" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="15" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing16" envelope="PTRP">
+     <mposPhi volume="PTSP" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="16" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing17" envelope="PTRQ">
+     <mposPhi volume="PTSQ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="17" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing18" envelope="PTRR">
+     <mposPhi volume="PTSR" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="18" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing19" envelope="PTRS">
+     <mposPhi volume="PTSS" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="19" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing20" envelope="PTRT">
+     <mposPhi volume="PTST" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="20" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing21" envelope="PTRU">
+     <mposPhi volume="PTSU" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="21" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing22" envelope="PTRV">
+     <mposPhi volume="PTSV" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="22" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing23" envelope="PTRW">
+     <mposPhi volume="PTSW" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="23" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing24" envelope="PTRX">
+     <mposPhi volume="PTSX" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="24" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+
+  <tubs name="PTRA" Rio_Z="11 12 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRB" Rio_Z="12 13 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRC" Rio_Z="13 14 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRD" Rio_Z="14 15 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRE" Rio_Z="15 16 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRF" Rio_Z="16 17 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRG" Rio_Z="17 18 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRH" Rio_Z="18 19 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRI" Rio_Z="19 20 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRJ" Rio_Z="20 21 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRK" Rio_Z="21 22 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRL" Rio_Z="22 23 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRM" Rio_Z="23 24 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRN" Rio_Z="24 25 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRO" Rio_Z="25 26 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRP" Rio_Z="26 27 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRQ" Rio_Z="27 28 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRR" Rio_Z="28 29 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRS" Rio_Z="29 30 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRT" Rio_Z="30 31 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRU" Rio_Z="31 32 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRV" Rio_Z="32 33 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRW" Rio_Z="33 34 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRX" Rio_Z="34 35 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTSA" Rio_Z="11 12 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSB" Rio_Z="12 13 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSC" Rio_Z="13 14 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSD" Rio_Z="14 15 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSE" Rio_Z="15 16 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSF" Rio_Z="16 17 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSG" Rio_Z="17 18 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSH" Rio_Z="18 19 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSI" Rio_Z="19 20 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSJ" Rio_Z="20 21 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSK" Rio_Z="21 22 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSL" Rio_Z="22 23 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSM" Rio_Z="23 24 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSN" Rio_Z="24 25 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSO" Rio_Z="25 26 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSP" Rio_Z="26 27 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSQ" Rio_Z="27 28 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSR" Rio_Z="28 29 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSS" Rio_Z="29 30 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTST" Rio_Z="30 31 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSU" Rio_Z="31 32 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSV" Rio_Z="32 33 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSW" Rio_Z="33 34 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSX" Rio_Z="34 35 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+
+  <tubs name="PTA1" Rio_Z="11 35 0.0006" material="Aluminum" unit_length="mm"
+                    comment="called blank1, whatever that is" />
+  <tubs name="PTA2" Rio_Z="11 35 0.0035" material="Silicon" unit_length="mm" 
+                    comment="called blank2, whatever that is" />
+  <tubs name="PTA3" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank3, whatever that is" />
+  <tubs name="PTA4" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank4, whatever that is" />
+  <tubs name="PTA5" Rio_Z="0.0 9.525 0.5" material="Vacuum" unit_length="mm"
+                    comment="called blank5, whatever that is" />
+
+  <composition name="tpolRecoilDetectorCard" envelope="PTCA">
+     <posXYZ volume="tpolRecoilDetector" />
+     <posXYZ volume="PTCH" />
+  </composition>
+
+  <pgon name="PTCA" segments="8" material="FR-4" unit_length="mm"
+                   comment="card that carries the recoil polarimeter detector">
+     <polyplane Rio_Z="0 60 -0.75" unit_length="mm" />
+     <polyplane Rio_Z="0 60 0.75" unit_length="mm" />
+  </pgon>
+  <tubs name="PTCH" Rio_Z="0.0 11.0 1.5" material="Vacuum" unit_length="mm"
+                   comment="central hole through the polarimeter card" />
+  
+  <tubs name="PTPB" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="beam pipe to the upstream/downstream" />
+  <tubs name="PTIB" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="beam vacuum to the upstream/downstream" />
+  <tubs name="PTPF" Rio_Z="1.9375 2.0 1.05" material="Iron" unit_length="in"
+                   comment="feed pipe to the side" />
+  <tubs name="PTIF" Rio_Z="0.0 1.9375 1.05" material="Vacuum" unit_length="in"
+                   comment="feed vacuum to the side" />
+  <tubs name="PTPT" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe" />
+  <tubs name="PTIT" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="turbo pump port vacuum" />
+  <tubs name="PTPM" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="motor port pipe" />
+  <tubs name="PTIM" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="motor port vacuum" />
+  <tubs name="PTPX" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="aux port pipe" />
+  <tubs name="PTIX" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="aux port vacuum" />
+  <tubs name="PTFB" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="beam pipe flange to the upstream/downstream" />
+  <tubs name="PTFX" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="aux port pipe flange" />
+  <tubs name="PTFT" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe flange" />
+  <tubs name="PTFM" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="motor port pipe flange" />
+  <tubs name="PTFF" Rio_Z="2.0 3.0 0.78" material="Iron" unit_length="in"
+                   comment="feed pipe flange" />
+  <tubs name="PTKX" Rio_Z="0.0 1.6875 0.5" material="Iron" unit_length="in"
+                   comment="aux port pipe cap" />
+  <tubs name="PTKM" Rio_Z="0.0 2.250 0.5" material="Iron" unit_length="in"
+                   comment="motor port pipe cap" />
+  <tubs name="PTKF" Rio_Z="0.0 3.0 0.5" material="Iron" unit_length="in"
+                   comment="feed pipe cap" />
+
+  <box name="PTMP" X_Y_Z="10.0 0.375 10.0" material="Aluminum" unit_length="in"
+                   comment="mounting plate" />
+  <box name="PTVR" X_Y_Z="6.0 0.51 0.25" material="Iron" unit_length="in"
+                   comment="vertical rack piece" />
+  <box name="PTHR" X_Y_Z="6.0 0.125 0.75" material="Iron" unit_length="in"
+                   comment="horizontal rack piece" />
+  <box name="PTBR" X_Y_Z="4.75 0.50 0.0625" material="Aluminum" unit_length="in"
+                   comment="horizontal bar piece" />
+  <box name="PTLG" X_Y_Z="0.5 7.987 0.125" material="Aluminum" unit_length="in"
+                   comment="support leg" />
+  <box name="PTVS" X_Y_Z="0.5 2.5 0.25" material="Aluminum" unit_length="in"
+                   comment="vertical support piece" />
+  <box name="PTHS" X_Y_Z="0.5 0.25 2.5" material="Aluminum" unit_length="in"
+                   comment="horizontal support piece" />
+  <box name="PTDR" X_Y_Z="1.0 15.0 17.0" material="Aluminum" unit_length="in"
+                   comment="vacuum box door" />
+
+  <!-- there is no mcfast model of the photon beamline -->
+
+</section>
+
+<!-- </HDDS> -->

--- a/BeamLine_HDDS_34_750.xml
+++ b/BeamLine_HDDS_34_750.xml
@@ -1,0 +1,1642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DOCTYPE HDDS>
+
+  Hall D Geometry Data Base: Beam Line
+  ************************************
+
+     version 1.0: Initial version	-rtj
+
+     Revision 1.1 10/18/2002 
+     -added concrete shielding to the collimator housing 
+     -added the virtual detectors to this code:
+        DET1: disk intercepting entire beam upstream of collimators
+        DET2: plane perpendicular to beam just after second collimator
+        DET3: plane mounted just below the ceiling of collimator cave
+        DET4: plane perpendicular to beam just after entry to hall
+        DET5: plane perpendicular to beam at photon dump end of hall
+        DET6: plane mounted just below the ceiling inside the hall
+        DET7: plane perpendicular to beam just before the target
+     -added a steel tube containing a vacuum that goes from the back of
+      the collimator to the front of the solenoid  
+     -csg-
+
+     Revision 1.2 10/28/2002
+     -revised collimator to the heavy shielding option 
+     -added a steel tube containing a vacuum in the WALL, SHLD and ABS2 volumes
+     -repositioned DET3 to be inside the collimator housing 
+     -removed the BEAM volume from the collimator system
+     -csg-
+
+     Revision 1.3 1/9/2003
+     -shrunk the size of the vacuum tube from r=5.3 to r=2.5 in order to
+      extend the tube into the second steering magnet
+     -csg-
+
+     Revision 1.4 06/16/2003
+     -mid-shielding option
+     -modified DET1, now a cylinder placed in front of primary collimator
+     -added tungsten pin-cushion detector model into simulation
+     -csg- 
+
+     Revision 2.0 05/16/2008
+     -moved DET2 to just after the second collimator, in agreement with
+      the comments below.  Somehow it got misplaced to upstream of the
+      second collimator.  I guess no one was using it until now.
+     -added the volume CONV for the pair conversion target located inside
+      the vacuum pipe just downstream of the second sweep magnet.  Right
+      now it its material is vacuum, but the thickness of 240 microns is
+      chosen to make a 0.1% converter if the material is set to Carbon.
+
+
+     Revision 2.1  12/12/2008, A.S., rtj
+       Made the following changes in the composition 'collimatorStack':
+  	  1. Added the composition BeamPipe0 describing a vacuum beam pipe at the entrance 
+             of the collimator cave:
+              - the beam pipe radius is 12.4 cm
+              - the exit window: 250 micron Kapton with the radius of 10.14 cm. 
+ 	  2. Moved the active collimator, DET1, and other components 83.96 cm upstream the 
+             beamline.
+          3. Changed layout of the 1st passive collimator to a composite W/Pb:
+	      - the inner part is a W  box,  5.08 x  5.08 x 20.0 cm3
+              - the outer part is a Pb box, 30.48 x 30.48 x 20.0 cm3 
+          4. Added  the vacuum beam pipe (Flange1 compositon) in front of the 1st sweeping 
+             magnet:
+              - use 150 micron Kapton entrance window
+              - vaccuum goes all the way downstream the beamline until the GlueX detector.
+          5. Modified the layout of the 1st sweeping magnet:
+              - the outer dimensions are 29.2 x 24.8 x 355.6 cm3
+              - the gap size is 10.22 x 4.9 cm2 
+              - the field inside the gap is 0.23 T (integrated field is 0.82 Tm)
+              - the elliptical vacuum pipe goes through the magnet. The semi-axes of the pipe 
+              are 4.95 cm and 2.29 cm.        
+          6. Added the concrete blocks around the 1st sweeping magnet, composition ConcreteWall1. 
+             The size of the wall is 101.6 x 147.32 x 121.92 cm3.
+          7. Added the composition Flange2 to connect the 1st sweeping magnet with a vacuum chamber.
+          8. Added a vacuum chamber after the 1st sweeping magnet with the following dimensions:
+              - 50.8 cm long tube with the inner and outer radii of Rin = 9.83 cm and Rout = 9.85.
+          9. Added the small lead wall after the vacuum chamber, composition LeadBand1.
+         10. Added the composition Flange3 to connect the vacuum pipe between the lead band and the
+             2nd collimatoor.
+         11. Changed material of the 2nd collimator from Nickel to Iron. The default pinhole 
+             diameter was changed from 1 cm to 0.6 cm.
+         12. Added the composition Flange4 to connect the vacuum pipe between the 2nd collimator and
+             the 2nd sweeping magnet.
+         13. Changed the layout of the second sweeping magnet:
+              - outer dimensions are 42 x 20.8 cm2
+              - the gap size is 20.3 x 5 cm2, the field in the gap is 0.23 T
+              - 1.75 cm radius vacuum beam pipe goes through the magnet.         
+         14. Added the composition Flange5 to connect 2nd the sweeping magnet with the vacuum beam 
+             pipe.           
+         15. Added a 1m long vacuum beam pipe. The inner and outer radii are 2.38 and 2.54 cm, 
+             respectively.
+         16. Added the small lead wall (composition LeadBand2), 81.28 x 20.32 x 10.16 cm3.
+         17. Placed the vertical plane DET2 after the lead wall. 
+         18. Added the composition Flange6 to connect the vacuum pipe between the lead wall and 
+             a pair spectrometer converter box.          
+         19. Added the pair spectrometer converter. The converter thickness and material can be set
+             in the box 'PTAR'   <box  name="PTAR" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />.
+         20. Added the composition Flange7 to connect the vacuum pipe between the converter and 
+             the concrete wall.
+         21. Modified the size of the concrete shielding wall to 450.0 x 270.0 x 121.92 cm3.
+             Added passage to the collimator cave.
+         22. Decreased thickness of the lead wall to 5.08 cm (size of the lead brick).
+              
+     Revision 2.2  12/22/2008
+       Modified the composition 'beamPipe'. Now 'beamPipe' extends the vacuum from the 
+       pair spectrometer to the position of the target.
+
+     Revision 3.0  3/2/2011
+       Large group of revisions, to reflect the beamline geometry and shielding
+       in the engineering drawings for the cave, and the new pair spectrometer.
+
+     Revision 3.1 9/6/2013
+       Updates for compatibility with geant4 -rtj
+       a) Many small shifts to various volumes to eliminate overlaps.
+       b) Changes to dimensions of the active collimator wedges, and even
+          the number of pins per row, so that all overlaps are eliminated.
+
+     Revision 3.2 12/12/2016
+       Updates to introduce the triplet polarimeter -rtj
+       a) renamed downstream PS converter target from PTAR to CONV
+       b) reserved the name PTAR for the triplet polarimeter target
+       c) incorporated a detailed geometric model of the triplet polarimeter
+          from the ASU group into the beamline geometry
+
+     Revision 3.3 3/27/2017
+     Added TAC and some material downstream the FCAL - A.S. 
+     - FCAL dark box window, FCAL platform pipe with plexiglass window, beam 
+     - intensity monitor, and TAC
+
+
+
+<HDDS specification="v1.0" xmlns="http://www.gluex.org/hdds">
+-->
+
+<section name        = "BeamLine"
+         version     = "3.2"
+         date        = "2016-12-12"
+         author      = "R.T. Jones"
+         top_volume  = "collimatorPackage"
+         specification = "v1.0">
+
+<!-- Origin of collimatorPackage is center of the entrance face of the
+     primary collimator.  					-->
+
+  <composition name="collimatorPackage">
+    <posXYZ volume="ShieldedCollimator" X_Y_Z="0.0  0.0  400.0" />
+  </composition>
+
+  <box name="SHLD" X_Y_Z="550.  550.  1300." material="Concrete"/>
+  <composition name="ShieldedCollimator" envelope="SHLD">
+    <posXYZ volume="pipeFromTaggerHall" X_Y_Z="0.0  0.0  -625.0" />
+    <posXYZ volume="collimatorCave" X_Y_Z="0.0  35.0  25.0" />
+  </composition>  
+ 
+  <box  name="CAVE" X_Y_Z="450. 270. 1250." material="Air" />
+  <composition name="collimatorCave" envelope="CAVE">
+    <posXYZ volume="collimatorStack" X_Y_Z="0.0 -35.0 -500.0"/>     
+<!--  <posXYZ volume="DET2" X_Y_Z="0.0  0.0  225.0" /> -->
+    <posXYZ volume="DET3" X_Y_Z="0.0  132.0  0.0" />
+  </composition>
+ 
+  <composition name="collimatorSubCave">
+    <posXYZ volume="collimatorStack" />
+  </composition>
+
+  <composition name="collimatorStack">
+    <posXYZ volume="BeamPipe0"     X_Y_Z="0.0  0.0  -125.0"  />
+    <!--posXYZ volume="PFLD"          X_Y_Z="0.0  0.0  -99.0"  />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -97.0"   />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -93.0"   /-->
+    <posXYZ volume="DET1"          X_Y_Z="0.0  0.0  -49.46"  />
+    <posXYZ volume="ColDetector"   X_Y_Z="0.0  0.0  -46.16"  />
+    <posXYZ volume="PrimaryCol"    X_Y_Z="0.0  0.0  -33.96"  />
+    <posXYZ volume="Flange1"       X_Y_Z="0.0  0.0   11.52"  />
+    <posXYZ volume="sweepMagnet1"  X_Y_Z="0.0  0.0   189.32" />
+    <posXYZ volume="ConcreteWall1" X_Y_Z="0.0  0.0   107.96" />
+    <posXYZ volume="Flange2"       X_Y_Z="0.0  0.0   367.12" />
+    <posXYZ volume="VacuumChamber" X_Y_Z="0.0  0.0   426.54" />
+    <posXYZ volume="LeadBand1"     X_Y_Z="0.0  0.0   457.02" />
+    <posXYZ volume="Flange3"       X_Y_Z="0.0  0.0   462.10" />
+    <posXYZ volume="COL2"          X_Y_Z="0.0  0.0   555.04" />
+    <posXYZ volume="Flange4"       X_Y_Z="0.0  0.0   580.44" />
+    <posXYZ volume="sweepMagnet2"  X_Y_Z="0.0  0.0   630.28" />
+    <posXYZ volume="Flange5"       X_Y_Z="0.0  0.0   648.28" />
+    <posXYZ volume="BeamPipe1"     X_Y_Z="0.0  0.0   712.28" />
+    <posXYZ volume="LeadBand2"     X_Y_Z="0.0  0.0   743.52" />
+    <posXYZ volume="DET2"          X_Y_Z="0.0  35.0  748.65" /> 
+    <posXYZ volume="Flange6"       X_Y_Z="0.0  0.0   748.70" />
+    <posXYZ volume="TripletPolar"  X_Y_Z="0.0 0.0    820.00" />
+    <posXYZ volume="Flange7"       X_Y_Z="0.0  0.0   840.954" />
+    <posXYZ volume="ConcreteWall2" X_Y_Z="0.0  33.0  941.24" />
+    <posXYZ volume="shieldingWall" X_Y_Z="0.0  35.0 1004.74" />     
+    <!--    <posXYZ volume="TargetBox"     X_Y_Z="0.0  0.0 1085.00" />   -->
+    <posXYZ volume="BeamPipe2"     X_Y_Z="0.0  0.0  1066.668" /> 
+  </composition>
+  
+<!-- Beam Pipe 0 -->
+
+  <composition name="pipeFromTaggerHall" envelope="PFTH">
+    <posXYZ volume="PFTV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PFTH" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="PFTV" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipe0">
+    <posXYZ volume="BeamPipeTube"    X_Y_Z="0.0  0.0  25.0" />
+    <posXYZ volume="BeamPipeFlange1" X_Y_Z="0.0  0.0  48.58" />
+    <posXYZ volume="BeamPipeExitWindow" X_Y_Z="0.0  0.0  50.0" />
+    <posXYZ volume="BeamPipeFlange2" X_Y_Z="0.0  0.0  51.42"  />
+  </composition>
+
+  <composition name="BeamPipeTube" envelope="BPTO">
+    <posXYZ volume="BPTI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPTO" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="BPTI" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipeFlange1">
+    <posXYZ volume="BFO1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BFO1" Rio_Z="12.7   15.24  2.84" material="Iron" />
+
+  <composition name="BeamPipeExitWindow">
+    <posXYZ volume="FCAP" X_Y_Z="0.0  0.0  0.0125"/>
+  </composition>
+
+  <tubs name="FCAP" Rio_Z="0.0   10.16   0.025" material="Kapton" />
+
+  <composition name="BeamPipeFlange2">
+    <posXYZ volume="BFO2" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="BFO2" Rio_Z="10.16   15.24   2.84"  material="Iron" />
+
+
+<!-- Primary Collimator -->
+
+  <composition name="PrimaryCol" envelope="PCPB">
+    <posXYZ volume="TungstenInsert" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="PCPB"  X_Y_Z="30.48  30.48  20." material="Lead" />
+
+  <composition name="TungstenInsert" envelope="PCTT">
+    <posXYZ volume="PCTH" X_Y_Z="0.0 0.0 0.0" />
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.02865 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.05730 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.11459 0 0" /-->
+  </composition>
+  <composition name="PrimaryCollimatorAperture" envelope="PCTH">
+    <posXYZ volume="PCTI" X_Y_Z="0.0 0.0 -5.0" />
+  </composition>
+
+  <box  name="PCTT"  X_Y_Z="5.08   5.08   20." material="Tungsten" />
+  <!--tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" /-->
+  <tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" />
+  <tubs name="PCTI"  Rio_Z="0.05   0.25   10." material="Tungsten" 
+        comment="pin-hole insert for reduced intensity running" />
+
+
+<!-- Flange 1 -->
+
+  <composition name="Flange1">
+    <posXYZ volume="FlangeOneDisk" X_Y_Z="0.0  0.0  -7.72" />
+    <posXYZ volume="FlangeOneWindow" X_Y_Z="0.0  0.0  -6.65" />
+    <posXYZ volume="FlangeOnePipe" X_Y_Z="0.0  0.0  -3.325" />
+  </composition>
+
+  <composition name="FlangeOneDisk">
+    <posXYZ volume="FOI1" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="FOI1" Rio_Z="1.27  8.57  2.14"  material="Iron" />
+
+  <composition name="FlangeOneWindow">
+    <posXYZ volume="F1CP" X_Y_Z="0.0  0.0  -0.0075"/>
+  </composition>
+
+  <tubs name="F1CP" Rio_Z="0.0   1.27  0.015" material="Kapton" />
+
+  <composition name="FlangeOnePipe" envelope="FOPO">
+    <posXYZ volume="FOPI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FOPO" Rxy_Z="5.11  2.45   6.65" material="Iron" />
+  <eltu name="FOPI" Rxy_Z="4.95  2.29   6.65" material="Vacuum" />
+
+
+<!-- 1st Sweeping Magnet -->
+
+  <composition name="sweepMagnet1" envelope="MAG1">
+    <posXYZ volume="POL1" X_Y_Z="0.0 +7.425 0.0" />
+    <posXYZ volume="POL1" X_Y_Z="0.0 -7.425 0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="-9.855 0.0  0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="+9.855 0.0  0.0" />
+    <posXYZ volume="MagnetPipe1" X_Y_Z="0.0  0.0  0.0" />
+  </composition> 
+
+  <box name="MAG1" X_Y_Z="29.2 24.8 355.6" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <box name="POL1" X_Y_Z="29.2  9.95  355.6" material="Iron" />
+  <box name="GAP1" X_Y_Z="9.49  4.9   355.6" material="Iron" />
+
+  <composition name="MagnetPipe1" envelope="MPO1">
+    <posXYZ volume="MPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="MPO1" Rxy_Z="5.11  2.45  355.6" material="Iron" />
+  <eltu name="MPI1" Rxy_Z="4.95  2.29  355.6" material="Vacuum" />
+
+
+<!-- Concrete Wall around the 1st sweeping magnet -->
+
+  <composition name="ConcreteWall1">
+    <posXYZ volume="WTOP" X_Y_Z="0.0   +30.3  0.0" />
+    <posXYZ volume="WBOT" X_Y_Z="0.0   -56.2  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="+32.7   0.0  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="-32.7   0.0  0.0" />
+  </composition> 
+
+  <box name="WTOP" X_Y_Z="101.6  35.8  121.92" material="Concrete" />
+  <box name="WBOT" X_Y_Z="101.6  87.6  121.92" material="Concrete" />
+  <box name="WSID" X_Y_Z="36.2   24.8  121.92" material="Concrete" />
+
+
+<!-- Flange 2 -->
+
+  <composition name="Flange2">
+    <posXYZ volume="FlangeTwoDisk1" X_Y_Z="0.0  0.0  2.29" />
+    <posXYZ volume="FlangeTwoDisk2" X_Y_Z="0.0  0.0  6.72"/>
+    <posXYZ volume="FlangeTwoDisk3" X_Y_Z="0.0  0.0  16.88"/>
+    <posXYZ volume="FlangeTwoDisk4" X_Y_Z="0.0  0.0  27.04"/>
+    <posXYZ volume="FlangeTwoDisk5" X_Y_Z="0.0  0.0  31.6"/>
+  </composition>
+
+  <composition name="FlangeTwoDisk1" envelope="FTO1">
+    <posXYZ volume="FTI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FTO1" Rxy_Z="5.11  2.45   4.58" material="Iron" />
+  <eltu name="FTI1" Rxy_Z="4.95  2.29   4.58" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk2" envelope="FTO2">
+    <posXYZ volume="FTI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO2" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI2" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk3" envelope="FTO3">
+    <posXYZ volume="FTI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO3" Rio_Z="0.0  6.21  16.04" material="Iron" />   
+  <tubs name="FTI3" Rio_Z="0.0  6.19  16.04" material="Vacuum" /> 
+
+  <composition name="FlangeTwoDisk4" envelope="FTO4">
+    <posXYZ volume="FTI4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO4" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI4" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk5" envelope="FTO5">
+    <posXYZ volume="FTI5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO5" Rio_Z="0.0  6.35   4.84" material="Iron" />
+  <tubs name="FTI5" Rio_Z="0.0  6.19   4.84" material="Vacuum" />
+
+
+<!-- Vacuum chamber after the 1st sweeping magnet-->
+
+  <composition name="VacuumChamber">
+    <posXYZ volume="VacuumChambDisk1" X_Y_Z="0.0 0.0 -25.30"/>
+    <posXYZ volume="VacuumChambDisk2" X_Y_Z="0.0 0.0  0.0"/>
+    <posXYZ volume="VacuumChambDisk3" X_Y_Z="0.0 0.0  25.30"/>
+  </composition>
+
+  <composition name="VacuumChambDisk1" envelope="VCO1">
+    <posXYZ volume="VCI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO1" Rio_Z="0.0  9.85   0.2" material="Iron" />
+  <tubs name="VCI1" Rio_Z="0.0  6.19   0.2" material="Vacuum" />
+
+  <composition name="VacuumChambDisk2" envelope="VCO2">
+    <posXYZ volume="VCI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO2" Rio_Z="0.0  9.85  50.40" material="Iron" />
+  <tubs name="VCI2" Rio_Z="0.0  9.83  50.40" material="Vacuum" />
+
+  <composition name="VacuumChambDisk3" envelope="VCO3">
+    <posXYZ volume="VCI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO3" Rio_Z="0.0  9.85  0.2" material="Iron" />
+  <tubs name="VCI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+
+<!-- Lead Band 1 -->
+
+  <composition name="LeadBand1" envelope="LBD1">
+    <posXYZ volume="LeadBandPipe1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe1" envelope="LBO1">
+    <posXYZ volume="LBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD1" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO1" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI1" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 3 -->
+
+  <composition name="Flange3">
+    <posXYZ volume="FlangeThreeDisk1" X_Y_Z="0.0  0.0  24.56" />
+    <posXYZ volume="FlangeThreeDisk2" X_Y_Z="0.0  0.0  50.70"/>
+    <posXYZ volume="FlangeThreeDisk3" X_Y_Z="0.0  0.0  55.78"/>
+    <posXYZ volume="FlangeThreeDisk4" X_Y_Z="0.0  0.0  60.86"/>
+    <posXYZ volume="FlangeThreeDisk5" X_Y_Z="0.0  0.0  64.99"/>
+  </composition>
+
+  <composition name="FlangeThreeDisk1" envelope="F3O1">
+    <posXYZ volume="F3I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O1" Rio_Z="0.0  2.54  49.12" material="Iron" />
+  <tubs name="F3I1" Rio_Z="0.0  2.38  49.12" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk2" envelope="F3O2">
+    <posXYZ volume="F3I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk3" envelope="F3O3">
+    <posXYZ volume="F3I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F3I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk4" envelope="F3O4">
+    <posXYZ volume="F3I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk5" envelope="F3O5">
+    <posXYZ volume="F3I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O5" Rio_Z="0.0  2.54   5.1" material="Iron" />
+  <tubs name="F3I5" Rio_Z="0.0  2.38   5.1" material="Vacuum" />
+
+
+<!-- 2nd Collimator -->
+
+  <composition name="COL2" envelope="OCOL">
+    <posXYZ volume="ICOL" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="OCOL" Rio_Z="0.0  10.0  50.8" material="Iron" />
+  <tubs name="ICOL" Rio_Z="0.0   0.5  50.8" material="Vacuum" />
+
+<!-- Flange 4 -->
+
+  <composition name="Flange4">
+    <posXYZ volume="FlangeFourDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFourDisk2" X_Y_Z="0.0  0.0  9.84"/>
+    <posXYZ volume="FlangeFourDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFourDisk4" X_Y_Z="0.0  0.0  20.0"/>
+    <posXYZ volume="FlangeFourDisk5" X_Y_Z="0.0  0.0  26.71"/>
+  </composition>
+
+  <composition name="FlangeFourDisk1" envelope="F4O1">
+    <posXYZ volume="F4I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F4I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+
+  <composition name="FlangeFourDisk2" envelope="F4O2">
+    <posXYZ volume="F4I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk3" envelope="F4O3">
+    <posXYZ volume="F4I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F4I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFourDisk4" envelope="F4O4">
+    <posXYZ volume="F4I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I4" Rio_Z="0.0  1.745  3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk5" envelope="F4O5">
+    <posXYZ volume="F4I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O5" Rio_Z="0.0  1.905   10.26" material="Iron" />
+  <tubs name="F4I5" Rio_Z="0.0  1.745   10.26" material="Vacuum" />
+
+
+<!-- 2nd Sweeping Magnet -->
+
+  <composition name="sweepMagnet2">
+    <posXYZ volume="Core" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Core" envelope="POL2">
+    <posXYZ volume="Aperture" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Aperture" envelope="GAP2">
+    <posXYZ volume="MagnetPipe2" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="POL2" X_Y_Z="42.0  20.8  36.0" material="Iron" />
+  <box name="GAP2" X_Y_Z="20.3   5.0  36.0" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <composition name="MagnetPipe2" envelope="MPO2">
+    <posXYZ volume="MPI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="MPO2" Rio_Z="0.0  1.905  36.0" material="Iron" />
+  <tubs name="MPI2" Rio_Z="0.0  1.745  36.0" material="Vacuum" />
+
+
+<!-- Flange 5 -->
+
+  <composition name="Flange5">
+    <posXYZ volume="FlangeFiveDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFiveDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeFiveDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFiveDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeFiveDisk5" X_Y_Z="0.0  0.0  29.71"/>
+  </composition>
+
+  <composition name="FlangeFiveDisk1" envelope="F5O1">
+    <posXYZ volume="F5I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O1" Rio_Z="0.0  1.905  8.26" material="Iron" />
+  <tubs name="F5I1" Rio_Z="0.0  1.745  8.26" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk2" envelope="F5O2">
+    <posXYZ volume="F5I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk3" envelope="F5O3">
+    <posXYZ volume="F5I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F5I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk4" envelope="F5O4">
+    <posXYZ volume="F5I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk5" envelope="F5O5">
+    <posXYZ volume="F5I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O5" Rio_Z="0.0  2.54  16.26" material="Iron" />
+  <tubs name="F5I5" Rio_Z="0.0  2.38  16.26" material="Vacuum" />
+
+
+<!-- Beam Pipe1 -->
+
+  <composition name="BeamPipe1" envelope="BPO1">
+    <posXYZ volume="BPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPO1" Rio_Z="0.0  2.54  52.32" material="Iron" />
+  <tubs name="BPI1" Rio_Z="0.0  2.38  52.32" material="Vacuum" />
+
+<!-- Lead Band 2 -->
+
+  <composition name="LeadBand2" envelope="LBD2">
+    <posXYZ volume="LeadBandPipe2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe2" envelope="LBO2">
+    <posXYZ volume="LBI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD2" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO2" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI2" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 6 -->
+
+<!-- Without DET2
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  25.71"/>
+  </composition>
+-->
+
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.08" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.74" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.82"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  19.9" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  35.98"/>
+  </composition>
+
+  <composition name="FlangeSixDisk1" envelope="F6O1">
+    <posXYZ volume="F6I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+<!-- Without DET2
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+-->
+
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.16" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk2" envelope="F6O2">
+    <posXYZ volume="F6I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk3" envelope="F6O3">
+    <posXYZ volume="F6I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F6I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSixDisk4" envelope="F6O4">
+    <posXYZ volume="F6I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk5" envelope="F6O5">
+    <posXYZ volume="F6I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O5" Rio_Z="0.0  2.54   29.0" material="Iron" />
+  <tubs name="F6I5" Rio_Z="0.0  2.38   29.0" material="Vacuum" />
+
+
+  <composition name="TargetBox">
+    <posXYZ volume="TargetBoxDisk1" X_Y_Z="0.0 0.0 -10.9"/>
+    <posXYZ volume="TargetBoxDisk2" X_Y_Z="0.0 0.0  0.0" />
+    <posXYZ volume="TargetBoxDisk3" X_Y_Z="0.0 0.0  10.9"/>
+  </composition>
+
+  <composition name="TargetBoxDisk1" envelope="TBO1">
+    <posXYZ volume="TBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO1" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI1" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+  <composition name="TargetBoxDisk2" envelope="TBO2">
+    <posXYZ volume="TargetInnerBox" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="TargetInnerBox" envelope="TBI2">
+    <posXYZ volume="CONV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO2" X_Y_Z="22.0  20.0  21.6" material="Iron" />
+  <box name="TBI2" X_Y_Z="21.6  19.6  21.6" material="Vacuum" />
+
+  <composition name="TargetBoxDisk3" envelope="TBO3">
+    <posXYZ volume="TBI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO3" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+  <box  name="CONV" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />
+
+
+
+
+
+
+<!-- Flange 7 -->
+
+  <composition name="Flange7">
+    <posXYZ volume="FlangeSevenDisk1" X_Y_Z="0.0  0.0  8.8721" />
+    <posXYZ volume="FlangeSevenDisk2" X_Y_Z="0.0  0.0  19.3224" />
+    <posXYZ volume="FlangeSevenDisk3" X_Y_Z="0.0  0.0  24.4024" />
+    <posXYZ volume="FlangeSevenDisk4" X_Y_Z="0.0  0.0  29.4824" />
+    <posXYZ volume="FlangeSevenDisk5" X_Y_Z="0.0  0.0  35.1924" />
+  </composition>
+
+  <composition name="FlangeSevenDisk1" envelope="F7O1">
+    <posXYZ volume="F7I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O1" Rio_Z="0.0  2.54  17.7424" material="Iron" />
+  <tubs name="F7I1" Rio_Z="0.0  2.38  17.7424" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk2" envelope="F7O2">
+    <posXYZ volume="F7I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk3" envelope="F7O3">
+    <posXYZ volume="F7I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F7I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk4" envelope="F7O4">
+    <posXYZ volume="F7I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk5" envelope="F7O5">
+    <posXYZ volume="F7I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O5" Rio_Z="0.0  2.54   8.26" material="Iron" />
+  <tubs name="F7I5" Rio_Z="0.0  2.38   8.26" material="Vacuum" />
+
+
+<!-- Concrete Wall -->
+
+  <composition name="ConcreteWall2" envelope="BLC2">
+    <posXYZ volume="ENTR" X_Y_Z="-179.0  0.0 -30.46"/>
+    <posXYZ volume="Block2Hole" X_Y_Z="0.0 -33.0 0.0"/>
+  </composition>
+
+  <box name="ENTR" X_Y_Z="92.0 266.0 61.0" material="Air" />
+
+  <composition name="Block2Hole" envelope="OBHO">
+    <posXYZ volume="IBHO"  X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="BLC2" X_Y_Z="450.0 266.0 121.92" material="Concrete" />
+  <tubs name="OBHO" Rio_Z="0.0  2.54  121.92" material="Iron" />
+  <tubs name="IBHO" Rio_Z="0.0  2.38  121.92" material="Vacuum" />
+
+
+<!-- Lead Wall -->
+
+  <composition name="shieldingWall" envelope="WALL">
+    <posXYZ volume="WallHole" X_Y_Z="0.0  -35.0  0.0"/>
+  </composition>
+
+  <box name="WALL" X_Y_Z="450. 270. 5.08" material="Lead" />
+
+  <composition name="WallHole" envelope="OWHO">
+    <posXYZ volume="IWHO" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="OWHO" Rio_Z="0.0  2.54 5.08" material="Iron" />
+  <tubs name="IWHO" Rio_Z="0.0  2.38 5.08" material="Vacuum" />
+
+
+<!-- Beam Pipe2 -->
+
+  <composition name="BeamPipe2" envelope="BPO2">
+  <!-- MUST COMMENT OUt either one or the other of the two lines below -->
+    <!-- <posXYZ volume="BeamPipe2Inner" /> enables the photon beam harp -->
+    <posXYZ volume="BPI2" /> <!-- disables the photon beam harp -->
+  </composition>
+  
+  <composition name="BeamPipe2Inner" envelope="BPI2">
+    <posXYZ volume="photonBeamHarp" X_Y_Z="0.0 0.0 -27.38" />
+  </composition>
+  
+  <composition name="photonBeamHarp">
+    <posXYZ volume="PSCV" />
+    <posXYZ volume="PSCH" />
+  </composition>
+
+  <tubs name="BPO2" Rio_Z="0.0  2.54   118.767" material="Iron" />
+  <tubs name="BPI2" Rio_Z="0.0  2.38   118.767" material="Vacuum" />
+    
+  <composition name="PairSpecConverter" envelope="PSCM">
+    <posXYZ volume="PSCV"/>
+    <posXYZ volume="PSCH"/>
+  </composition>
+  
+  <tubs name="PSCM" Rio_Z="0.0 2.38 0.53" material="Vacuum"/>
+  <tubs name="PSCV" Rio_Z="0.0 1.143 0.01" material="Aluminum"/>
+  <tubs name="PSCH" Rio_Z="1.143 2.38 0.53" material="Iron"/>
+
+  <tubs name="DET1" Rio_Z="0.   50.  2." material="Air" />
+  <box name="DET2" X_Y_Z=" 450. 270. 0.1" material="Vacuum" />
+  <box name="DET3" X_Y_Z=" 450. 2. 918." material="Air" />
+
+  
+<!-- The composition 'beamPipe' extends the vacuum from the pair 
+     spectrometer to the position of the target.
+
+     Origin of beamPipe is center of the hall.
+-->
+
+  <composition name="beamPipe">
+<!--    <posXYZ volume="DET4"     X_Y_Z="  0.0     0.0 -1400.0"/> -->
+    <posXYZ volume="DET5"     X_Y_Z="  0.0     0.0  1400.0"/> 
+    <posXYZ volume="TAC1" X_Y_Z="150.0  -350.0  1225.0" />  
+    <posXYZ volume="DarkWindow" X_Y_Z="  150.0  -350.0  320.0" />
+    <posXYZ volume="PlatformPipe" X_Y_Z="150.0  -350.0  650."/>
+    <posXYZ volume="PlexWindow" X_Y_Z="150.0  -350.0  830."/>
+    <posXYZ volume="IntMonitor" X_Y_Z="150.0  -350.0  834."/>
+    <posXYZ volume="DET6"     X_Y_Z="  0.0   600.0     0.0"/>
+    <!--posXYZ volume="DET7"     X_Y_Z="  0.0     0.0  -705.0"/--> 
+    <posXYZ volume="HallBellows" X_Y_Z="150.0 -350.0 -1223.287"/>
+    <posXYZ volume="HallPipe" X_Y_Z="150.0  -350.0  -1026.77"/>
+    <!-- Plastic scintillator for beam diagonistics -->
+    <!--posXYZ volume="DET8" X_Y_Z="150 -350.0 -834.0 "/-->
+  </composition>
+
+  <composition name="DarkWindow">
+    <posXYZ volume="DBOW" X_Y_Z="  0.0  0.0  0.0" />
+    <posXYZ volume="DBEW" X_Y_Z="  0.0  0.0  0.0" />
+  </composition>
+
+  <tubs name="DBOW" Rio_Z="20.0  60.0  0.3"  material="Aluminum"/>
+  <tubs name="DBEW" Rio_Z="0.0   20.0  0.01" material="Tedlar"/>
+
+  <composition name="PlatformPipe">
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0  -176.5127" />
+    <posXYZ volume="PipeSection" X_Y_Z="0.0 0.0 0.0" />
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0   176.5127" />
+  </composition>
+
+  <tubs name="PPWD" Rio_Z="0.0   20.32  0.0254" material="Kapton" />
+
+  <composition name="PipeSection" envelope="PPOV">
+    <posXYZ volume="PPIV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PPOV" Rio_Z="0.0   20.32  353.0" material="Iron" />
+  <tubs name="PPIV" Rio_Z="0.0   20.04  353.0" material="Vacuum" />
+
+  <composition name="PlexWindow">
+    <posXYZ volume="PPPW" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="IntMonitor" >
+    <posXYZ volume="INTM" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box  name="INTM" X_Y_Z="2  6  1" material="Scintillator"  />
+
+  <tubs name="PPPW" Rio_Z="0.0   20.32  0.3" material="Plexiglas" />
+
+  <box  name="TAC1" X_Y_Z="20  20  45" material="leadGlassF800" sensitive="true" />
+
+
+  <box name="DET4" X_Y_Z="1700.0  1200.0  2.0" material="Vacuum" />
+  <box name="DET5" X_Y_Z="1700.0  1198.0  2.0" material="Air" />
+  <box name="DET6" X_Y_Z="1700.0  2.0  3000.0" material="Air" />
+  <!--box name="DET7" X_Y_Z="1700.0  1198.0  2.0" material="Air" /-->
+  <tubs name="DET7" Rio_Z="0.0 1.7399  2.0" material="Vacuum"
+        comment="disk detector inside beam pipe at target entrance" />
+  <box name="DET8" X_Y_Z="10.0 10.0 1.0" material="Scintillator" sensitive="true"/>
+
+<!-- Hall bellows -->
+<composition name="HallBellows" envelope="BLWO">
+  <posXYZ volume="BLWI" X_Y_Z="0.0 0.0 -3.5011"/>
+</composition>
+
+<pcon name="BLWO" material="Iron">
+  <polyplane Rio_Z="0.0 1.90500 -13.4"/>
+  <polyplane Rio_Z="0.0 1.90500 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 6.3978"/>
+</pcon>
+
+<tubs name="BLWI" Rio_Z="0. 1.7399 19.7978" material="Vacuum"/>
+
+<!-- Hall Pipe -->
+  <composition name="HallPipe" envelope="OHPI" >
+    <!--posXYZ volume="IHPI" X_Y_Z="0 0 98.6305"/-->
+    <posXYZ volume="InnerHallPipe" X_Y_Z="0.0 0.0 98.6305"/> 
+  </composition>
+
+  <composition name="InnerHallPipe" envelope="IHPI">
+    <posXYZ volume="DET7" X_Y_Z="0 0 280.0"/> 
+    <!--posXYZ volume="CAP1" X_Y_Z="0.0  0.0  190.11265" /-->
+  </composition>
+
+
+  <pcon name="OHPI" material="Iron">
+    <polyplane Rio_Z="0.0 4.27355 -190.1190"/>
+    <polyplane Rio_Z="0.0 4.27355 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +387.380"/>
+  </pcon>
+
+  <tubs name="IHPI" Rio_Z="0.0  1.7399 577.499" material="Vacuum" />
+  <tubs name="CAP1" Rio_Z="0.0  1.7399 0.0127" material="Kapton"/>
+
+<composition name="SixWayCross" envelope="SWCM">
+  <posXYZ volume="sixWayTube" X_Y_Z="0 0 0"/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0 0." rot="0. 180. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 90. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 270. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="90. 0. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="270. 0. 0."/>
+  <posXYZ volume="sixWayBox" X_Y_Z="0. 0. 0."/> 
+</composition>
+
+<box name="SWCM" X_Y_Z="67.9196 67.9196 67.9196" material="Air"
+     comment="Six-way cross mother volume"/>
+<pcon name="SWCP" material="StainlessSteel" comment="Vacuum pipe for 6-way cross">
+  <polyplane Rio_Z="0. 20.32 20.32"/>
+  <polyplane Rio_Z="0. 20.32 32.258"/>
+  <polyplane Rio_Z="0. 22.504 32.258"/>
+  <polyplane Rio_Z="0. 22.504 33.9598"/>
+</pcon>
+  
+<composition name="sixWayTube" envelope="SWCP">
+  <posXYZ volume="SWC2" X_Y_Z="0.0 0.0 27.1399"/>
+</composition>
+
+<composition name="sixWayBox" envelope="SWCB">
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 -20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 -20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="20.08125 0. 0." rot="0 90 0 "/>
+  <posXYZ volume="SWC1" X_Y_Z="-20.08125 0. 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeMotherVolume" X_Y_Z="0. 0. 0." />
+</composition>
+
+<composition name="coldCubeMotherVolume" envelope="CBXM">
+  <posXYZ volume="CBX1" X_Y_Z="0. -7.712  0."/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.1444"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.3032"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 -12.1444"/>
+  <posXYZ volume="CBXS" X_Y_Z="12.1444 4.28 0."/>
+  <posXYZ volume="CBXS" X_Y_Z="-12.1444 4.28 0."/>
+  <posXYZ volume="coldCubeTopPlate" X_Y_Z="0. 16.272 0." rot="90 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 -11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="11.9856 4.28 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="-11.9856 4.28 0." rot="0 90 0"/>
+</composition>
+
+<composition name="coldCubeBeamPlate" envelope="CBXB">
+  <posXYZ volume="CBH0" X_Y_Z="0. -4.2926 0."/>
+</composition>
+
+<composition name="coldCubeSidePlate" envelope="CBSP">
+  <posXYZ volume="CBH2" X_Y_Z="0. 0. 0."/>
+</composition>
+
+<composition name="coldCubeTopPlate" envelope="CHXT">
+  <posXYZ volume="CBH1" X_Y_Z="0. 0. 0." />
+</composition>
+
+<box name="CBSP" X_Y_Z="23.8124 23.8124 0.15875" material="Copper"/>
+<box name="CHXT" X_Y_Z="24.13 24.13 0.15875" material="Copper"/>
+<tubs name="CBH1" Rio_Z="0. 10.795 0.15875" material="Vacuum"/>
+<tubs name="CBH0" Rio_Z="0 1.27 0.15875" material="Vacuum" 
+      comment="Hole for beam"/>
+<box name="CBH2" X_Y_Z="19.05 19.05 0.15875" material="Vacuum"/>
+<box name="CBXB" X_Y_Z="21.8948 21.8948 0.15875" material="Copper"/>
+<box name="CBXS" X_Y_Z="0.15875 21.8948 21.8948" material="Copper"/>
+<box name="CBX1" X_Y_Z="24.13 0.15875 24.13" material="Copper"/>
+<box name="CBXM" X_Y_Z="39.685 39.685 39.685" material="Vacuum"/>
+<box name="SWCB" X_Y_Z="40.64 40.64 40.64" material="StainlessSteel"/>
+<tubs name="SWC1" Rio_Z="0 19.84248 0.4775" material="Vacuum"/>
+<tubs name="SWC2" Rio_Z="0. 19.84248 13.6398" material="Vacuum"/>
+
+<!-- Approximation for the beam profiler -->
+<box name="PFSC" X_Y_Z="12.8 12.8 0.2" material="Scintillator" sensitive="true"/>
+<box name="PFLD" X_Y_Z="10.0 10.0 0.1" material="Lead"/>
+
+<!-- Following is the definition of the active collimator.  It sits
+     on the upstream end of the primary collimator and acts as an
+     active absorber with segmented detection of the beam intensity.
+-->
+
+  <composition name="ColDetector" envelope="INSU">
+    <posXYZ volume="ColAssemblyFinal" X_Y_Z="0.0 0.0 0.50"/>
+    <posXYZ volume="HOUF" X_Y_Z="0.0  0.0  -1.85"/>
+  </composition>
+
+  <composition name="ColAssemblyFinal" envelope="HOUS">
+    <posXYZ volume="ColAssemblyInitial" X_Y_Z="0.0  0.0  -0.15"/>
+  </composition>
+  
+  <composition name="ColAssemblyInitial" envelope="AIRH">
+    <mposPhi volume="DIV1" ncopy="4" Phi0="0" dPhi="90" R_Z="3.375 0."/>  
+    <mposPhi volume="DIV2" ncopy="4" Phi0="45" dPhi="90"/>  
+    <mposPhi volume="innerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+    <mposPhi volume="outerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+  </composition>
+
+  <tubs name="INSU" Rio_Z="0.25   7.36  4.20" material="BoronNitride"/>
+ 
+  <tubs name="HOUS" Rio_Z="0.25   6.70  3.20" material="Aluminum" />
+ 
+  <tubs name="HOUF" Rio_Z="0.25   6.85  0.50" material="Aluminum"/>
+ 
+  <tubs name="AIRH" Rio_Z="0.25   6.5002  2.9" material="Air" />
+  <box  name="DIV1" X_Y_Z="6.25  0.1  2.9" material="Aluminum" />
+  <tubs name="DIV2" Rio_Z="2.7   2.8  2.9" profile="-42.870 85.740"
+                                           material="Aluminum" />
+
+  <composition name="innerPinCushionWedge" envelope="ACWI">
+    <posXYZ volume="ACBI" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="innerPinCushionRow_1" X_Y_Z="0.276 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_2" X_Y_Z="0.376 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_3" X_Y_Z="0.476 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_4" X_Y_Z="0.576 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_5" X_Y_Z="0.676 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_6" X_Y_Z="0.776 0.0 0.40" />
+  </composition>
+  <composition name="innerPinCushionRow_1" envelope="AIR1">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_2" envelope="AIR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_3" envelope="AIR3">
+    <mposY volume="PIN1" ncopy="5" Y0="-0.20" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_4" envelope="AIR4">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_5" envelope="AIR5">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_6" envelope="AIR6">
+    <mposY volume="PIN1" ncopy="9" Y0="-0.40" dY="0.10" />
+  </composition>
+
+  <composition name="outerPinCushionWedge" envelope="ACWO">
+    <posXYZ volume="ACBO" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 -1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 +1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 -1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 +1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 -1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 +1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 -1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 +1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_5" X_Y_Z="3.025 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_6" X_Y_Z="3.125 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_7" X_Y_Z="3.225 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_8" X_Y_Z="3.325 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_9" X_Y_Z="3.425 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_10" X_Y_Z="3.525 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_11" X_Y_Z="3.625 0.0 0.40" />
+  </composition>
+  <composition name="outerPinCushionRow_1" envelope="AOR1">
+    <posXYZ volume="PIN1" />
+  </composition>
+  <composition name="outerPinCushionRow_2" envelope="AOR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_3" envelope="AOR3">
+    <mposY volume="PIN1" ncopy="6" Y0="-0.25" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_4" envelope="AOR4">
+    <mposY volume="PIN1" ncopy="10" Y0="-0.45" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_5" envelope="AOR5">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_6" envelope="AOR6">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_7" envelope="AOR7">
+    <mposY volume="PIN1" ncopy="37" Y0="-1.80" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_8" envelope="AOR8">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_9" envelope="AOR9">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_10" envelope="AORA">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_11" envelope="AORB">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+
+  <tubs name="ACWI" Rio_Z="0.25 2.5  2.5" profile="-33. 66."
+         material="Air" comment="active collimator inner wedge" />  
+  <tubs name="ACWO" Rio_Z="2.97  6.0  2.5" profile="-33. 66."
+         material="Air" comment="active collimator outer wedge" />  
+  <tubs name="ACBI" Rio_Z="0.25 2.5  0.8" profile="-32. 64."
+         material="SoftTungsten" comment="inner wedge base plate" />  
+  <tubs name="ACBO" Rio_Z="3.0  6.0  0.8" profile="-30. 60."
+         material="SoftTungsten" comment="outer wedge base plate" />  
+
+  <box name="AIR1" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AIR2" X_Y_Z="0.051 0.40 1.7" material="Air" />
+  <box name="AIR3" X_Y_Z="0.051 0.50 1.7" material="Air" />
+  <box name="AIR4" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AIR5" X_Y_Z="0.051 0.80 1.7" material="Air" />
+  <box name="AIR6" X_Y_Z="0.051 0.90 1.7" material="Air" />
+
+  <box name="AOR1" X_Y_Z="0.051 0.10 1.7" material="Air" />
+  <box name="AOR2" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AOR3" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AOR4" X_Y_Z="0.051 1.00 1.7" material="Air" />
+  <box name="AOR5" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR6" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR7" X_Y_Z="0.051 3.70 1.7" material="Air" />
+  <box name="AOR8" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AOR9" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AORA" X_Y_Z="0.051 4.10 1.7" material="Air" />
+  <box name="AORB" X_Y_Z="0.051 4.10 1.7" material="Air" />
+
+  <box name="PIN1" X_Y_Z="0.051 0.051 1.7" material="SoftTungsten" />
+ 
+<!-- Following is the definition of the triplet polarimeter.  It sits
+     just before of the shielding wall at the downstream end of the
+     collimator cave, and contains a retractable pair conversion target
+     called PTAR. Forward pairs are detected in the pair spectrometer.
+-->
+
+<!-- Origin of TripletPolar is the beam axis midpoint
+     of the polarimeter vacuum box, as set by the outside walls. -->
+
+  <composition name="TripletPolar">
+     <apply region="nullBfield"/>
+     <posXYZ volume="tripletPolar" X_Y_Z="1.5 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tripletPolar">
+     <posXYZ volume="tpolEnclosure" />
+     <posXYZ volume="tpolVacuumBoxFlange" X_Y_Z="6.50 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTPT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTPM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTIT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTIM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFT" X_Y_Z="0.0 -7.91 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTFM" X_Y_Z="-4.0 4.0 +7.91" unit_length="in" />
+     <posXYZ volume="PTFF" X_Y_Z="-6.910 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 -8.5" unit_length="in" />
+     <posXYZ volume="PTKM" X_Y_Z="-4.0 4.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKF" X_Y_Z="-7.550 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTDR" X_Y_Z="7.25 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tpolVacuumBox" envelope="PTB0">
+     <posXYZ volume="tpolRailGuide" X_Y_Z="0.375 5.131 -3.380" unit_length="in" />
+     <posXYZ volume="tpolTargetCarrier" X_Y_Z="0.25 2.146 -3.380" rot="0 180 0" unit_length="in" />
+     <posXYZ volume="tpolTargetMotor" X_Y_Z="-1.625 4.1449 -1.6284" unit_length="in" />
+     <posXYZ volume="tpolRecoilDetectorCard" X_Y_Z="-1.625 0.0 -2.0" rot="0 0 22.5" unit_length="in" />
+     <posXYZ volume="PTA1" X_Y_Z="-1.625 0.0 -1.9796" unit_length="in" />
+     <posXYZ volume="PTA2" X_Y_Z="-1.625 0.0 -1.9795" unit_length="in" />
+     <posXYZ volume="PTA3" X_Y_Z="-1.625 0.0 -1.9794" unit_length="in" />
+     <posXYZ volume="PTA4" X_Y_Z="-1.625 0.0 -2.0204" unit_length="in" />
+     <!-- <posXYZ volume="PTA5" X_Y_Z="-1.625 0.0 -3.3651" unit_length="in" /> -->
+     <posXYZ volume="PTMP" X_Y_Z="0.0 5.8125 0.0" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 -5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 -4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="-5.125 5.745 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="-4.625 5.5525 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 -2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="0.4872 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="-3.7372 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="0.4872 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="-3.7372 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="0.4872 5.5 -0.6216" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="-3.7372 5.5 -0.6216" unit_length="in" />
+  </composition>
+
+  <composition name="tpolEnclosure" envelope="PTBO">
+     <posXYZ volume="tpolVacuumBox" X_Y_Z="0.125 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH3" X_Y_Z="-4.0 4.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH6" X_Y_Z="0.0 -6.125 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH5" X_Y_Z="-6.125 0.0 -2.0" rot="0 90 0" unit_length="in" />
+  </composition>
+
+  
+  <tubs name="PTAR" Rio_Z="0.0 0.375 0.0750" material="Beryllium" 
+	comment="polarimeter converter target" /> 
+  
+  
+  <box name="PTBO" X_Y_Z="12.5 12.5 12.5" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube1" />
+  <box name="PTB0" X_Y_Z="12.25 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube2" />
+  <box name="PTB1" X_Y_Z="0.5 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box flange subtraction" />
+  <box name="PTB2" X_Y_Z="0.5 15.0 17.0" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box door flange" />
+  <box name="PTB3" X_Y_Z="9.25 0.988 0.625" material="Aluminum" unit_length="in"
+                   comment="polarimeter rail guide" />
+  <box name="PTB4" X_Y_Z="9.25 0.312 0.125" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail gap subtraction" />
+  <box name="PTB5" X_Y_Z="9.25 0.365 0.375" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail box subtraction" />
+  <box name="PTB6" X_Y_Z="42.0 42.0 2.0" material="Iron" unit_length="mm"
+                   comment="polarimeter motor plate" />
+  <box name="PTB7" X_Y_Z="5.25 5.792 0.118" material="Aluminum" unit_length="in"
+                   comment="polarimeter target holder" />
+  <box name="PTB8" X_Y_Z="4.325 4.292 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter target holder subtraction" />
+  <tubs name="PTH0" Rio_Z="0.0 21.0 69.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motor" />
+  <tubs name="PTH1" Rio_Z="0.0 10.5 32.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motion gear" />
+  <tubs name="PTH2" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter beam hole subtraction" />
+  <tubs name="PTH3" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter motor hole subtraction" />
+  <tubs name="PTH4" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter auxilliary hole subtraction" />
+  <tubs name="PTH5" Rio_Z="0.0 1.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter feed hole subtraction" />
+  <tubs name="PTH6" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter turbo pump hole subtraction" />
+  <tubs name="PTH7" Rio_Z="0.0 0.375 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter converter tray subtraction" />
+
+  <composition name="tpolVacuumBoxFlange" envelope="PTB2">
+     <posXYZ volume="PTB1" />
+  </composition>
+  <composition name="tpolRailGuide" envelope="PTB3">
+     <posXYZ volume="PTB4" X_Y_Z="0.0 -0.338 0.0" unit_length="in" />
+     <posXYZ volume="PTB5" />
+  </composition>
+  <composition name="tpolTargetDisk" envelope="PTH7">
+     <posXYZ volume="PTAR" />
+  </composition>
+  <composition name="tpolTargetCarrier" envelope="PTB7">
+     <posXYZ volume="PTB8" X_Y_Z="0.4625 0.75 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="1.875 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="0.625 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="-0.625 -2.146 0.0" unit_length="in" />
+  </composition>
+  <composition name="tpolTargetMotor">
+     <posXYZ volume="PTH0" />
+     <posXYZ volume="PTB6" X_Y_Z="0.0 0.0 -35.5" unit_length="mm" />
+     <posXYZ volume="PTH1" X_Y_Z="0.0 0.0 -52.5" unit_length="mm" />
+  </composition>
+  
+  <composition name="tpolRecoilDetector" envelope="PTDE">
+     <posXYZ volume="tpolRecoilRing1" />
+     <posXYZ volume="tpolRecoilRing2" />
+     <posXYZ volume="tpolRecoilRing3" />
+     <posXYZ volume="tpolRecoilRing4" />
+     <posXYZ volume="tpolRecoilRing5" />
+     <posXYZ volume="tpolRecoilRing6" />
+     <posXYZ volume="tpolRecoilRing7" />
+     <posXYZ volume="tpolRecoilRing8" />
+     <posXYZ volume="tpolRecoilRing9" />
+     <posXYZ volume="tpolRecoilRing10" />
+     <posXYZ volume="tpolRecoilRing11" />
+     <posXYZ volume="tpolRecoilRing12" />
+     <posXYZ volume="tpolRecoilRing13" />
+     <posXYZ volume="tpolRecoilRing14" />
+     <posXYZ volume="tpolRecoilRing15" />
+     <posXYZ volume="tpolRecoilRing16" />
+     <posXYZ volume="tpolRecoilRing17" />
+     <posXYZ volume="tpolRecoilRing18" />
+     <posXYZ volume="tpolRecoilRing19" />
+     <posXYZ volume="tpolRecoilRing20" />
+     <posXYZ volume="tpolRecoilRing21" />
+     <posXYZ volume="tpolRecoilRing22" />
+     <posXYZ volume="tpolRecoilRing23" />
+     <posXYZ volume="tpolRecoilRing24" />
+  </composition>
+  <tubs name="PTDE" Rio_Z="11.0 35.0 1.5" material="Vacuum" unit_length="mm" 
+                   comment="container for the triplet polarimeter detector" />
+
+  <composition name="tpolRecoilRing1" envelope="PTRA">
+     <mposPhi volume="PTSA" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="1" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing2" envelope="PTRB">
+     <mposPhi volume="PTSB" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="2" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing3" envelope="PTRC">
+     <mposPhi volume="PTSC" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="3" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing4" envelope="PTRD">
+     <mposPhi volume="PTSD" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="4" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing5" envelope="PTRE">
+     <mposPhi volume="PTSE" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="5" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing6" envelope="PTRF">
+     <mposPhi volume="PTSF" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="6" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing7" envelope="PTRG">
+     <mposPhi volume="PTSG" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="7" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing8" envelope="PTRH">
+     <mposPhi volume="PTSH" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="8" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing9" envelope="PTRI">
+     <mposPhi volume="PTSI" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="9" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing10" envelope="PTRJ">
+     <mposPhi volume="PTSJ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="10" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing11" envelope="PTRK">
+     <mposPhi volume="PTSK" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="11" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing12" envelope="PTRL">
+     <mposPhi volume="PTSL" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="12" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing13" envelope="PTRM">
+     <mposPhi volume="PTSM" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="13" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing14" envelope="PTRN">
+     <mposPhi volume="PTSN" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="14" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing15" envelope="PTRO">
+     <mposPhi volume="PTSO" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="15" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing16" envelope="PTRP">
+     <mposPhi volume="PTSP" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="16" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing17" envelope="PTRQ">
+     <mposPhi volume="PTSQ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="17" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing18" envelope="PTRR">
+     <mposPhi volume="PTSR" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="18" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing19" envelope="PTRS">
+     <mposPhi volume="PTSS" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="19" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing20" envelope="PTRT">
+     <mposPhi volume="PTST" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="20" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing21" envelope="PTRU">
+     <mposPhi volume="PTSU" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="21" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing22" envelope="PTRV">
+     <mposPhi volume="PTSV" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="22" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing23" envelope="PTRW">
+     <mposPhi volume="PTSW" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="23" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing24" envelope="PTRX">
+     <mposPhi volume="PTSX" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="24" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+
+  <tubs name="PTRA" Rio_Z="11 12 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRB" Rio_Z="12 13 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRC" Rio_Z="13 14 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRD" Rio_Z="14 15 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRE" Rio_Z="15 16 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRF" Rio_Z="16 17 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRG" Rio_Z="17 18 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRH" Rio_Z="18 19 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRI" Rio_Z="19 20 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRJ" Rio_Z="20 21 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRK" Rio_Z="21 22 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRL" Rio_Z="22 23 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRM" Rio_Z="23 24 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRN" Rio_Z="24 25 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRO" Rio_Z="25 26 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRP" Rio_Z="26 27 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRQ" Rio_Z="27 28 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRR" Rio_Z="28 29 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRS" Rio_Z="29 30 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRT" Rio_Z="30 31 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRU" Rio_Z="31 32 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRV" Rio_Z="32 33 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRW" Rio_Z="33 34 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRX" Rio_Z="34 35 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTSA" Rio_Z="11 12 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSB" Rio_Z="12 13 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSC" Rio_Z="13 14 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSD" Rio_Z="14 15 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSE" Rio_Z="15 16 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSF" Rio_Z="16 17 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSG" Rio_Z="17 18 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSH" Rio_Z="18 19 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSI" Rio_Z="19 20 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSJ" Rio_Z="20 21 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSK" Rio_Z="21 22 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSL" Rio_Z="22 23 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSM" Rio_Z="23 24 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSN" Rio_Z="24 25 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSO" Rio_Z="25 26 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSP" Rio_Z="26 27 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSQ" Rio_Z="27 28 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSR" Rio_Z="28 29 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSS" Rio_Z="29 30 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTST" Rio_Z="30 31 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSU" Rio_Z="31 32 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSV" Rio_Z="32 33 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSW" Rio_Z="33 34 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSX" Rio_Z="34 35 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+
+  <tubs name="PTA1" Rio_Z="11 35 0.0006" material="Aluminum" unit_length="mm"
+                    comment="called blank1, whatever that is" />
+  <tubs name="PTA2" Rio_Z="11 35 0.0035" material="Silicon" unit_length="mm" 
+                    comment="called blank2, whatever that is" />
+  <tubs name="PTA3" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank3, whatever that is" />
+  <tubs name="PTA4" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank4, whatever that is" />
+  <tubs name="PTA5" Rio_Z="0.0 9.525 0.5" material="Vacuum" unit_length="mm"
+                    comment="called blank5, whatever that is" />
+
+  <composition name="tpolRecoilDetectorCard" envelope="PTCA">
+     <posXYZ volume="tpolRecoilDetector" />
+     <posXYZ volume="PTCH" />
+  </composition>
+
+  <pgon name="PTCA" segments="8" material="FR-4" unit_length="mm"
+                   comment="card that carries the recoil polarimeter detector">
+     <polyplane Rio_Z="0 60 -0.75" unit_length="mm" />
+     <polyplane Rio_Z="0 60 0.75" unit_length="mm" />
+  </pgon>
+  <tubs name="PTCH" Rio_Z="0.0 11.0 1.5" material="Vacuum" unit_length="mm"
+                   comment="central hole through the polarimeter card" />
+  
+  <tubs name="PTPB" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="beam pipe to the upstream/downstream" />
+  <tubs name="PTIB" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="beam vacuum to the upstream/downstream" />
+  <tubs name="PTPF" Rio_Z="1.9375 2.0 1.05" material="Iron" unit_length="in"
+                   comment="feed pipe to the side" />
+  <tubs name="PTIF" Rio_Z="0.0 1.9375 1.05" material="Vacuum" unit_length="in"
+                   comment="feed vacuum to the side" />
+  <tubs name="PTPT" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe" />
+  <tubs name="PTIT" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="turbo pump port vacuum" />
+  <tubs name="PTPM" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="motor port pipe" />
+  <tubs name="PTIM" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="motor port vacuum" />
+  <tubs name="PTPX" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="aux port pipe" />
+  <tubs name="PTIX" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="aux port vacuum" />
+  <tubs name="PTFB" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="beam pipe flange to the upstream/downstream" />
+  <tubs name="PTFX" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="aux port pipe flange" />
+  <tubs name="PTFT" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe flange" />
+  <tubs name="PTFM" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="motor port pipe flange" />
+  <tubs name="PTFF" Rio_Z="2.0 3.0 0.78" material="Iron" unit_length="in"
+                   comment="feed pipe flange" />
+  <tubs name="PTKX" Rio_Z="0.0 1.6875 0.5" material="Iron" unit_length="in"
+                   comment="aux port pipe cap" />
+  <tubs name="PTKM" Rio_Z="0.0 2.250 0.5" material="Iron" unit_length="in"
+                   comment="motor port pipe cap" />
+  <tubs name="PTKF" Rio_Z="0.0 3.0 0.5" material="Iron" unit_length="in"
+                   comment="feed pipe cap" />
+
+  <box name="PTMP" X_Y_Z="10.0 0.375 10.0" material="Aluminum" unit_length="in"
+                   comment="mounting plate" />
+  <box name="PTVR" X_Y_Z="6.0 0.51 0.25" material="Iron" unit_length="in"
+                   comment="vertical rack piece" />
+  <box name="PTHR" X_Y_Z="6.0 0.125 0.75" material="Iron" unit_length="in"
+                   comment="horizontal rack piece" />
+  <box name="PTBR" X_Y_Z="4.75 0.50 0.0625" material="Aluminum" unit_length="in"
+                   comment="horizontal bar piece" />
+  <box name="PTLG" X_Y_Z="0.5 7.987 0.125" material="Aluminum" unit_length="in"
+                   comment="support leg" />
+  <box name="PTVS" X_Y_Z="0.5 2.5 0.25" material="Aluminum" unit_length="in"
+                   comment="vertical support piece" />
+  <box name="PTHS" X_Y_Z="0.5 0.25 2.5" material="Aluminum" unit_length="in"
+                   comment="horizontal support piece" />
+  <box name="PTDR" X_Y_Z="1.0 15.0 17.0" material="Aluminum" unit_length="in"
+                   comment="vacuum box door" />
+
+  <!-- there is no mcfast model of the photon beamline -->
+
+</section>
+
+<!-- </HDDS> -->

--- a/BeamLine_HDDS_50_0.xml
+++ b/BeamLine_HDDS_50_0.xml
@@ -1,0 +1,1642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DOCTYPE HDDS>
+
+  Hall D Geometry Data Base: Beam Line
+  ************************************
+
+     version 1.0: Initial version	-rtj
+
+     Revision 1.1 10/18/2002 
+     -added concrete shielding to the collimator housing 
+     -added the virtual detectors to this code:
+        DET1: disk intercepting entire beam upstream of collimators
+        DET2: plane perpendicular to beam just after second collimator
+        DET3: plane mounted just below the ceiling of collimator cave
+        DET4: plane perpendicular to beam just after entry to hall
+        DET5: plane perpendicular to beam at photon dump end of hall
+        DET6: plane mounted just below the ceiling inside the hall
+        DET7: plane perpendicular to beam just before the target
+     -added a steel tube containing a vacuum that goes from the back of
+      the collimator to the front of the solenoid  
+     -csg-
+
+     Revision 1.2 10/28/2002
+     -revised collimator to the heavy shielding option 
+     -added a steel tube containing a vacuum in the WALL, SHLD and ABS2 volumes
+     -repositioned DET3 to be inside the collimator housing 
+     -removed the BEAM volume from the collimator system
+     -csg-
+
+     Revision 1.3 1/9/2003
+     -shrunk the size of the vacuum tube from r=5.3 to r=2.5 in order to
+      extend the tube into the second steering magnet
+     -csg-
+
+     Revision 1.4 06/16/2003
+     -mid-shielding option
+     -modified DET1, now a cylinder placed in front of primary collimator
+     -added tungsten pin-cushion detector model into simulation
+     -csg- 
+
+     Revision 2.0 05/16/2008
+     -moved DET2 to just after the second collimator, in agreement with
+      the comments below.  Somehow it got misplaced to upstream of the
+      second collimator.  I guess no one was using it until now.
+     -added the volume CONV for the pair conversion target located inside
+      the vacuum pipe just downstream of the second sweep magnet.  Right
+      now it its material is vacuum, but the thickness of 240 microns is
+      chosen to make a 0.1% converter if the material is set to Carbon.
+
+
+     Revision 2.1  12/12/2008, A.S., rtj
+       Made the following changes in the composition 'collimatorStack':
+  	  1. Added the composition BeamPipe0 describing a vacuum beam pipe at the entrance 
+             of the collimator cave:
+              - the beam pipe radius is 12.4 cm
+              - the exit window: 250 micron Kapton with the radius of 10.14 cm. 
+ 	  2. Moved the active collimator, DET1, and other components 83.96 cm upstream the 
+             beamline.
+          3. Changed layout of the 1st passive collimator to a composite W/Pb:
+	      - the inner part is a W  box,  5.08 x  5.08 x 20.0 cm3
+              - the outer part is a Pb box, 30.48 x 30.48 x 20.0 cm3 
+          4. Added  the vacuum beam pipe (Flange1 compositon) in front of the 1st sweeping 
+             magnet:
+              - use 150 micron Kapton entrance window
+              - vaccuum goes all the way downstream the beamline until the GlueX detector.
+          5. Modified the layout of the 1st sweeping magnet:
+              - the outer dimensions are 29.2 x 24.8 x 355.6 cm3
+              - the gap size is 10.22 x 4.9 cm2 
+              - the field inside the gap is 0.23 T (integrated field is 0.82 Tm)
+              - the elliptical vacuum pipe goes through the magnet. The semi-axes of the pipe 
+              are 4.95 cm and 2.29 cm.        
+          6. Added the concrete blocks around the 1st sweeping magnet, composition ConcreteWall1. 
+             The size of the wall is 101.6 x 147.32 x 121.92 cm3.
+          7. Added the composition Flange2 to connect the 1st sweeping magnet with a vacuum chamber.
+          8. Added a vacuum chamber after the 1st sweeping magnet with the following dimensions:
+              - 50.8 cm long tube with the inner and outer radii of Rin = 9.83 cm and Rout = 9.85.
+          9. Added the small lead wall after the vacuum chamber, composition LeadBand1.
+         10. Added the composition Flange3 to connect the vacuum pipe between the lead band and the
+             2nd collimatoor.
+         11. Changed material of the 2nd collimator from Nickel to Iron. The default pinhole 
+             diameter was changed from 1 cm to 0.6 cm.
+         12. Added the composition Flange4 to connect the vacuum pipe between the 2nd collimator and
+             the 2nd sweeping magnet.
+         13. Changed the layout of the second sweeping magnet:
+              - outer dimensions are 42 x 20.8 cm2
+              - the gap size is 20.3 x 5 cm2, the field in the gap is 0.23 T
+              - 1.75 cm radius vacuum beam pipe goes through the magnet.         
+         14. Added the composition Flange5 to connect 2nd the sweeping magnet with the vacuum beam 
+             pipe.           
+         15. Added a 1m long vacuum beam pipe. The inner and outer radii are 2.38 and 2.54 cm, 
+             respectively.
+         16. Added the small lead wall (composition LeadBand2), 81.28 x 20.32 x 10.16 cm3.
+         17. Placed the vertical plane DET2 after the lead wall. 
+         18. Added the composition Flange6 to connect the vacuum pipe between the lead wall and 
+             a pair spectrometer converter box.          
+         19. Added the pair spectrometer converter. The converter thickness and material can be set
+             in the box 'PTAR'   <box  name="PTAR" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />.
+         20. Added the composition Flange7 to connect the vacuum pipe between the converter and 
+             the concrete wall.
+         21. Modified the size of the concrete shielding wall to 450.0 x 270.0 x 121.92 cm3.
+             Added passage to the collimator cave.
+         22. Decreased thickness of the lead wall to 5.08 cm (size of the lead brick).
+              
+     Revision 2.2  12/22/2008
+       Modified the composition 'beamPipe'. Now 'beamPipe' extends the vacuum from the 
+       pair spectrometer to the position of the target.
+
+     Revision 3.0  3/2/2011
+       Large group of revisions, to reflect the beamline geometry and shielding
+       in the engineering drawings for the cave, and the new pair spectrometer.
+
+     Revision 3.1 9/6/2013
+       Updates for compatibility with geant4 -rtj
+       a) Many small shifts to various volumes to eliminate overlaps.
+       b) Changes to dimensions of the active collimator wedges, and even
+          the number of pins per row, so that all overlaps are eliminated.
+
+     Revision 3.2 12/12/2016
+       Updates to introduce the triplet polarimeter -rtj
+       a) renamed downstream PS converter target from PTAR to CONV
+       b) reserved the name PTAR for the triplet polarimeter target
+       c) incorporated a detailed geometric model of the triplet polarimeter
+          from the ASU group into the beamline geometry
+
+     Revision 3.3 3/27/2017
+     Added TAC and some material downstream the FCAL - A.S. 
+     - FCAL dark box window, FCAL platform pipe with plexiglass window, beam 
+     - intensity monitor, and TAC
+
+
+
+<HDDS specification="v1.0" xmlns="http://www.gluex.org/hdds">
+-->
+
+<section name        = "BeamLine"
+         version     = "3.2"
+         date        = "2016-12-12"
+         author      = "R.T. Jones"
+         top_volume  = "collimatorPackage"
+         specification = "v1.0">
+
+<!-- Origin of collimatorPackage is center of the entrance face of the
+     primary collimator.  					-->
+
+  <composition name="collimatorPackage">
+    <posXYZ volume="ShieldedCollimator" X_Y_Z="0.0  0.0  400.0" />
+  </composition>
+
+  <box name="SHLD" X_Y_Z="550.  550.  1300." material="Concrete"/>
+  <composition name="ShieldedCollimator" envelope="SHLD">
+    <posXYZ volume="pipeFromTaggerHall" X_Y_Z="0.0  0.0  -625.0" />
+    <posXYZ volume="collimatorCave" X_Y_Z="0.0  35.0  25.0" />
+  </composition>  
+ 
+  <box  name="CAVE" X_Y_Z="450. 270. 1250." material="Air" />
+  <composition name="collimatorCave" envelope="CAVE">
+    <posXYZ volume="collimatorStack" X_Y_Z="0.0 -35.0 -500.0"/>     
+<!--  <posXYZ volume="DET2" X_Y_Z="0.0  0.0  225.0" /> -->
+    <posXYZ volume="DET3" X_Y_Z="0.0  132.0  0.0" />
+  </composition>
+ 
+  <composition name="collimatorSubCave">
+    <posXYZ volume="collimatorStack" />
+  </composition>
+
+  <composition name="collimatorStack">
+    <posXYZ volume="BeamPipe0"     X_Y_Z="0.0  0.0  -125.0"  />
+    <!--posXYZ volume="PFLD"          X_Y_Z="0.0  0.0  -99.0"  />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -97.0"   />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -93.0"   /-->
+    <posXYZ volume="DET1"          X_Y_Z="0.0  0.0  -49.46"  />
+    <posXYZ volume="ColDetector"   X_Y_Z="0.0  0.0  -46.16"  />
+    <posXYZ volume="PrimaryCol"    X_Y_Z="0.0  0.0  -33.96"  />
+    <posXYZ volume="Flange1"       X_Y_Z="0.0  0.0   11.52"  />
+    <posXYZ volume="sweepMagnet1"  X_Y_Z="0.0  0.0   189.32" />
+    <posXYZ volume="ConcreteWall1" X_Y_Z="0.0  0.0   107.96" />
+    <posXYZ volume="Flange2"       X_Y_Z="0.0  0.0   367.12" />
+    <posXYZ volume="VacuumChamber" X_Y_Z="0.0  0.0   426.54" />
+    <posXYZ volume="LeadBand1"     X_Y_Z="0.0  0.0   457.02" />
+    <posXYZ volume="Flange3"       X_Y_Z="0.0  0.0   462.10" />
+    <posXYZ volume="COL2"          X_Y_Z="0.0  0.0   555.04" />
+    <posXYZ volume="Flange4"       X_Y_Z="0.0  0.0   580.44" />
+    <posXYZ volume="sweepMagnet2"  X_Y_Z="0.0  0.0   630.28" />
+    <posXYZ volume="Flange5"       X_Y_Z="0.0  0.0   648.28" />
+    <posXYZ volume="BeamPipe1"     X_Y_Z="0.0  0.0   712.28" />
+    <posXYZ volume="LeadBand2"     X_Y_Z="0.0  0.0   743.52" />
+    <posXYZ volume="DET2"          X_Y_Z="0.0  35.0  748.65" /> 
+    <posXYZ volume="Flange6"       X_Y_Z="0.0  0.0   748.70" />
+    <posXYZ volume="TripletPolar"  X_Y_Z="0.0 0.0    820.00" />
+    <posXYZ volume="Flange7"       X_Y_Z="0.0  0.0   840.954" />
+    <posXYZ volume="ConcreteWall2" X_Y_Z="0.0  33.0  941.24" />
+    <posXYZ volume="shieldingWall" X_Y_Z="0.0  35.0 1004.74" />     
+    <!--    <posXYZ volume="TargetBox"     X_Y_Z="0.0  0.0 1085.00" />   -->
+    <posXYZ volume="BeamPipe2"     X_Y_Z="0.0  0.0  1066.668" /> 
+  </composition>
+  
+<!-- Beam Pipe 0 -->
+
+  <composition name="pipeFromTaggerHall" envelope="PFTH">
+    <posXYZ volume="PFTV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PFTH" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="PFTV" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipe0">
+    <posXYZ volume="BeamPipeTube"    X_Y_Z="0.0  0.0  25.0" />
+    <posXYZ volume="BeamPipeFlange1" X_Y_Z="0.0  0.0  48.58" />
+    <posXYZ volume="BeamPipeExitWindow" X_Y_Z="0.0  0.0  50.0" />
+    <posXYZ volume="BeamPipeFlange2" X_Y_Z="0.0  0.0  51.42"  />
+  </composition>
+
+  <composition name="BeamPipeTube" envelope="BPTO">
+    <posXYZ volume="BPTI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPTO" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="BPTI" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipeFlange1">
+    <posXYZ volume="BFO1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BFO1" Rio_Z="12.7   15.24  2.84" material="Iron" />
+
+  <composition name="BeamPipeExitWindow">
+    <posXYZ volume="FCAP" X_Y_Z="0.0  0.0  0.0125"/>
+  </composition>
+
+  <tubs name="FCAP" Rio_Z="0.0   10.16   0.025" material="Kapton" />
+
+  <composition name="BeamPipeFlange2">
+    <posXYZ volume="BFO2" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="BFO2" Rio_Z="10.16   15.24   2.84"  material="Iron" />
+
+
+<!-- Primary Collimator -->
+
+  <composition name="PrimaryCol" envelope="PCPB">
+    <posXYZ volume="TungstenInsert" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="PCPB"  X_Y_Z="30.48  30.48  20." material="Lead" />
+
+  <composition name="TungstenInsert" envelope="PCTT">
+    <posXYZ volume="PCTH" X_Y_Z="0.0 0.0 0.0" />
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.02865 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.05730 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.11459 0 0" /-->
+  </composition>
+  <composition name="PrimaryCollimatorAperture" envelope="PCTH">
+    <posXYZ volume="PCTI" X_Y_Z="0.0 0.0 -5.0" />
+  </composition>
+
+  <box  name="PCTT"  X_Y_Z="5.08   5.08   20." material="Tungsten" />
+  <!--tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" /-->
+  <tubs name="PCTH"  Rio_Z="0.0    0.25   20." material="Air" />
+  <tubs name="PCTI"  Rio_Z="0.05   0.25   10." material="Tungsten" 
+        comment="pin-hole insert for reduced intensity running" />
+
+
+<!-- Flange 1 -->
+
+  <composition name="Flange1">
+    <posXYZ volume="FlangeOneDisk" X_Y_Z="0.0  0.0  -7.72" />
+    <posXYZ volume="FlangeOneWindow" X_Y_Z="0.0  0.0  -6.65" />
+    <posXYZ volume="FlangeOnePipe" X_Y_Z="0.0  0.0  -3.325" />
+  </composition>
+
+  <composition name="FlangeOneDisk">
+    <posXYZ volume="FOI1" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="FOI1" Rio_Z="1.27  8.57  2.14"  material="Iron" />
+
+  <composition name="FlangeOneWindow">
+    <posXYZ volume="F1CP" X_Y_Z="0.0  0.0  -0.0075"/>
+  </composition>
+
+  <tubs name="F1CP" Rio_Z="0.0   1.27  0.015" material="Kapton" />
+
+  <composition name="FlangeOnePipe" envelope="FOPO">
+    <posXYZ volume="FOPI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FOPO" Rxy_Z="5.11  2.45   6.65" material="Iron" />
+  <eltu name="FOPI" Rxy_Z="4.95  2.29   6.65" material="Vacuum" />
+
+
+<!-- 1st Sweeping Magnet -->
+
+  <composition name="sweepMagnet1" envelope="MAG1">
+    <posXYZ volume="POL1" X_Y_Z="0.0 +7.425 0.0" />
+    <posXYZ volume="POL1" X_Y_Z="0.0 -7.425 0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="-9.855 0.0  0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="+9.855 0.0  0.0" />
+    <posXYZ volume="MagnetPipe1" X_Y_Z="0.0  0.0  0.0" />
+  </composition> 
+
+  <box name="MAG1" X_Y_Z="29.2 24.8 355.6" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <box name="POL1" X_Y_Z="29.2  9.95  355.6" material="Iron" />
+  <box name="GAP1" X_Y_Z="9.49  4.9   355.6" material="Iron" />
+
+  <composition name="MagnetPipe1" envelope="MPO1">
+    <posXYZ volume="MPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="MPO1" Rxy_Z="5.11  2.45  355.6" material="Iron" />
+  <eltu name="MPI1" Rxy_Z="4.95  2.29  355.6" material="Vacuum" />
+
+
+<!-- Concrete Wall around the 1st sweeping magnet -->
+
+  <composition name="ConcreteWall1">
+    <posXYZ volume="WTOP" X_Y_Z="0.0   +30.3  0.0" />
+    <posXYZ volume="WBOT" X_Y_Z="0.0   -56.2  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="+32.7   0.0  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="-32.7   0.0  0.0" />
+  </composition> 
+
+  <box name="WTOP" X_Y_Z="101.6  35.8  121.92" material="Concrete" />
+  <box name="WBOT" X_Y_Z="101.6  87.6  121.92" material="Concrete" />
+  <box name="WSID" X_Y_Z="36.2   24.8  121.92" material="Concrete" />
+
+
+<!-- Flange 2 -->
+
+  <composition name="Flange2">
+    <posXYZ volume="FlangeTwoDisk1" X_Y_Z="0.0  0.0  2.29" />
+    <posXYZ volume="FlangeTwoDisk2" X_Y_Z="0.0  0.0  6.72"/>
+    <posXYZ volume="FlangeTwoDisk3" X_Y_Z="0.0  0.0  16.88"/>
+    <posXYZ volume="FlangeTwoDisk4" X_Y_Z="0.0  0.0  27.04"/>
+    <posXYZ volume="FlangeTwoDisk5" X_Y_Z="0.0  0.0  31.6"/>
+  </composition>
+
+  <composition name="FlangeTwoDisk1" envelope="FTO1">
+    <posXYZ volume="FTI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FTO1" Rxy_Z="5.11  2.45   4.58" material="Iron" />
+  <eltu name="FTI1" Rxy_Z="4.95  2.29   4.58" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk2" envelope="FTO2">
+    <posXYZ volume="FTI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO2" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI2" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk3" envelope="FTO3">
+    <posXYZ volume="FTI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO3" Rio_Z="0.0  6.21  16.04" material="Iron" />   
+  <tubs name="FTI3" Rio_Z="0.0  6.19  16.04" material="Vacuum" /> 
+
+  <composition name="FlangeTwoDisk4" envelope="FTO4">
+    <posXYZ volume="FTI4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO4" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI4" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk5" envelope="FTO5">
+    <posXYZ volume="FTI5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO5" Rio_Z="0.0  6.35   4.84" material="Iron" />
+  <tubs name="FTI5" Rio_Z="0.0  6.19   4.84" material="Vacuum" />
+
+
+<!-- Vacuum chamber after the 1st sweeping magnet-->
+
+  <composition name="VacuumChamber">
+    <posXYZ volume="VacuumChambDisk1" X_Y_Z="0.0 0.0 -25.30"/>
+    <posXYZ volume="VacuumChambDisk2" X_Y_Z="0.0 0.0  0.0"/>
+    <posXYZ volume="VacuumChambDisk3" X_Y_Z="0.0 0.0  25.30"/>
+  </composition>
+
+  <composition name="VacuumChambDisk1" envelope="VCO1">
+    <posXYZ volume="VCI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO1" Rio_Z="0.0  9.85   0.2" material="Iron" />
+  <tubs name="VCI1" Rio_Z="0.0  6.19   0.2" material="Vacuum" />
+
+  <composition name="VacuumChambDisk2" envelope="VCO2">
+    <posXYZ volume="VCI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO2" Rio_Z="0.0  9.85  50.40" material="Iron" />
+  <tubs name="VCI2" Rio_Z="0.0  9.83  50.40" material="Vacuum" />
+
+  <composition name="VacuumChambDisk3" envelope="VCO3">
+    <posXYZ volume="VCI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO3" Rio_Z="0.0  9.85  0.2" material="Iron" />
+  <tubs name="VCI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+
+<!-- Lead Band 1 -->
+
+  <composition name="LeadBand1" envelope="LBD1">
+    <posXYZ volume="LeadBandPipe1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe1" envelope="LBO1">
+    <posXYZ volume="LBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD1" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO1" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI1" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 3 -->
+
+  <composition name="Flange3">
+    <posXYZ volume="FlangeThreeDisk1" X_Y_Z="0.0  0.0  24.56" />
+    <posXYZ volume="FlangeThreeDisk2" X_Y_Z="0.0  0.0  50.70"/>
+    <posXYZ volume="FlangeThreeDisk3" X_Y_Z="0.0  0.0  55.78"/>
+    <posXYZ volume="FlangeThreeDisk4" X_Y_Z="0.0  0.0  60.86"/>
+    <posXYZ volume="FlangeThreeDisk5" X_Y_Z="0.0  0.0  64.99"/>
+  </composition>
+
+  <composition name="FlangeThreeDisk1" envelope="F3O1">
+    <posXYZ volume="F3I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O1" Rio_Z="0.0  2.54  49.12" material="Iron" />
+  <tubs name="F3I1" Rio_Z="0.0  2.38  49.12" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk2" envelope="F3O2">
+    <posXYZ volume="F3I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk3" envelope="F3O3">
+    <posXYZ volume="F3I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F3I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk4" envelope="F3O4">
+    <posXYZ volume="F3I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk5" envelope="F3O5">
+    <posXYZ volume="F3I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O5" Rio_Z="0.0  2.54   5.1" material="Iron" />
+  <tubs name="F3I5" Rio_Z="0.0  2.38   5.1" material="Vacuum" />
+
+
+<!-- 2nd Collimator -->
+
+  <composition name="COL2" envelope="OCOL">
+    <posXYZ volume="ICOL" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="OCOL" Rio_Z="0.0  10.0  50.8" material="Iron" />
+  <tubs name="ICOL" Rio_Z="0.0   0.5  50.8" material="Vacuum" />
+
+<!-- Flange 4 -->
+
+  <composition name="Flange4">
+    <posXYZ volume="FlangeFourDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFourDisk2" X_Y_Z="0.0  0.0  9.84"/>
+    <posXYZ volume="FlangeFourDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFourDisk4" X_Y_Z="0.0  0.0  20.0"/>
+    <posXYZ volume="FlangeFourDisk5" X_Y_Z="0.0  0.0  26.71"/>
+  </composition>
+
+  <composition name="FlangeFourDisk1" envelope="F4O1">
+    <posXYZ volume="F4I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F4I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+
+  <composition name="FlangeFourDisk2" envelope="F4O2">
+    <posXYZ volume="F4I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk3" envelope="F4O3">
+    <posXYZ volume="F4I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F4I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFourDisk4" envelope="F4O4">
+    <posXYZ volume="F4I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I4" Rio_Z="0.0  1.745  3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk5" envelope="F4O5">
+    <posXYZ volume="F4I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O5" Rio_Z="0.0  1.905   10.26" material="Iron" />
+  <tubs name="F4I5" Rio_Z="0.0  1.745   10.26" material="Vacuum" />
+
+
+<!-- 2nd Sweeping Magnet -->
+
+  <composition name="sweepMagnet2">
+    <posXYZ volume="Core" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Core" envelope="POL2">
+    <posXYZ volume="Aperture" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Aperture" envelope="GAP2">
+    <posXYZ volume="MagnetPipe2" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="POL2" X_Y_Z="42.0  20.8  36.0" material="Iron" />
+  <box name="GAP2" X_Y_Z="20.3   5.0  36.0" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <composition name="MagnetPipe2" envelope="MPO2">
+    <posXYZ volume="MPI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="MPO2" Rio_Z="0.0  1.905  36.0" material="Iron" />
+  <tubs name="MPI2" Rio_Z="0.0  1.745  36.0" material="Vacuum" />
+
+
+<!-- Flange 5 -->
+
+  <composition name="Flange5">
+    <posXYZ volume="FlangeFiveDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFiveDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeFiveDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFiveDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeFiveDisk5" X_Y_Z="0.0  0.0  29.71"/>
+  </composition>
+
+  <composition name="FlangeFiveDisk1" envelope="F5O1">
+    <posXYZ volume="F5I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O1" Rio_Z="0.0  1.905  8.26" material="Iron" />
+  <tubs name="F5I1" Rio_Z="0.0  1.745  8.26" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk2" envelope="F5O2">
+    <posXYZ volume="F5I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk3" envelope="F5O3">
+    <posXYZ volume="F5I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F5I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk4" envelope="F5O4">
+    <posXYZ volume="F5I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk5" envelope="F5O5">
+    <posXYZ volume="F5I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O5" Rio_Z="0.0  2.54  16.26" material="Iron" />
+  <tubs name="F5I5" Rio_Z="0.0  2.38  16.26" material="Vacuum" />
+
+
+<!-- Beam Pipe1 -->
+
+  <composition name="BeamPipe1" envelope="BPO1">
+    <posXYZ volume="BPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPO1" Rio_Z="0.0  2.54  52.32" material="Iron" />
+  <tubs name="BPI1" Rio_Z="0.0  2.38  52.32" material="Vacuum" />
+
+<!-- Lead Band 2 -->
+
+  <composition name="LeadBand2" envelope="LBD2">
+    <posXYZ volume="LeadBandPipe2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe2" envelope="LBO2">
+    <posXYZ volume="LBI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD2" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO2" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI2" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 6 -->
+
+<!-- Without DET2
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  25.71"/>
+  </composition>
+-->
+
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.08" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.74" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.82"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  19.9" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  35.98"/>
+  </composition>
+
+  <composition name="FlangeSixDisk1" envelope="F6O1">
+    <posXYZ volume="F6I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+<!-- Without DET2
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+-->
+
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.16" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk2" envelope="F6O2">
+    <posXYZ volume="F6I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk3" envelope="F6O3">
+    <posXYZ volume="F6I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F6I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSixDisk4" envelope="F6O4">
+    <posXYZ volume="F6I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk5" envelope="F6O5">
+    <posXYZ volume="F6I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O5" Rio_Z="0.0  2.54   29.0" material="Iron" />
+  <tubs name="F6I5" Rio_Z="0.0  2.38   29.0" material="Vacuum" />
+
+
+  <composition name="TargetBox">
+    <posXYZ volume="TargetBoxDisk1" X_Y_Z="0.0 0.0 -10.9"/>
+    <posXYZ volume="TargetBoxDisk2" X_Y_Z="0.0 0.0  0.0" />
+    <posXYZ volume="TargetBoxDisk3" X_Y_Z="0.0 0.0  10.9"/>
+  </composition>
+
+  <composition name="TargetBoxDisk1" envelope="TBO1">
+    <posXYZ volume="TBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO1" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI1" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+  <composition name="TargetBoxDisk2" envelope="TBO2">
+    <posXYZ volume="TargetInnerBox" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="TargetInnerBox" envelope="TBI2">
+    <posXYZ volume="CONV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO2" X_Y_Z="22.0  20.0  21.6" material="Iron" />
+  <box name="TBI2" X_Y_Z="21.6  19.6  21.6" material="Vacuum" />
+
+  <composition name="TargetBoxDisk3" envelope="TBO3">
+    <posXYZ volume="TBI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO3" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+  <box  name="CONV" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />
+
+
+
+
+
+
+<!-- Flange 7 -->
+
+  <composition name="Flange7">
+    <posXYZ volume="FlangeSevenDisk1" X_Y_Z="0.0  0.0  8.8721" />
+    <posXYZ volume="FlangeSevenDisk2" X_Y_Z="0.0  0.0  19.3224" />
+    <posXYZ volume="FlangeSevenDisk3" X_Y_Z="0.0  0.0  24.4024" />
+    <posXYZ volume="FlangeSevenDisk4" X_Y_Z="0.0  0.0  29.4824" />
+    <posXYZ volume="FlangeSevenDisk5" X_Y_Z="0.0  0.0  35.1924" />
+  </composition>
+
+  <composition name="FlangeSevenDisk1" envelope="F7O1">
+    <posXYZ volume="F7I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O1" Rio_Z="0.0  2.54  17.7424" material="Iron" />
+  <tubs name="F7I1" Rio_Z="0.0  2.38  17.7424" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk2" envelope="F7O2">
+    <posXYZ volume="F7I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk3" envelope="F7O3">
+    <posXYZ volume="F7I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F7I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk4" envelope="F7O4">
+    <posXYZ volume="F7I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk5" envelope="F7O5">
+    <posXYZ volume="F7I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O5" Rio_Z="0.0  2.54   8.26" material="Iron" />
+  <tubs name="F7I5" Rio_Z="0.0  2.38   8.26" material="Vacuum" />
+
+
+<!-- Concrete Wall -->
+
+  <composition name="ConcreteWall2" envelope="BLC2">
+    <posXYZ volume="ENTR" X_Y_Z="-179.0  0.0 -30.46"/>
+    <posXYZ volume="Block2Hole" X_Y_Z="0.0 -33.0 0.0"/>
+  </composition>
+
+  <box name="ENTR" X_Y_Z="92.0 266.0 61.0" material="Air" />
+
+  <composition name="Block2Hole" envelope="OBHO">
+    <posXYZ volume="IBHO"  X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="BLC2" X_Y_Z="450.0 266.0 121.92" material="Concrete" />
+  <tubs name="OBHO" Rio_Z="0.0  2.54  121.92" material="Iron" />
+  <tubs name="IBHO" Rio_Z="0.0  2.38  121.92" material="Vacuum" />
+
+
+<!-- Lead Wall -->
+
+  <composition name="shieldingWall" envelope="WALL">
+    <posXYZ volume="WallHole" X_Y_Z="0.0  -35.0  0.0"/>
+  </composition>
+
+  <box name="WALL" X_Y_Z="450. 270. 5.08" material="Lead" />
+
+  <composition name="WallHole" envelope="OWHO">
+    <posXYZ volume="IWHO" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="OWHO" Rio_Z="0.0  2.54 5.08" material="Iron" />
+  <tubs name="IWHO" Rio_Z="0.0  2.38 5.08" material="Vacuum" />
+
+
+<!-- Beam Pipe2 -->
+
+  <composition name="BeamPipe2" envelope="BPO2">
+  <!-- MUST COMMENT OUt either one or the other of the two lines below -->
+    <!-- <posXYZ volume="BeamPipe2Inner" /> enables the photon beam harp -->
+    <posXYZ volume="BPI2" /> <!-- disables the photon beam harp -->
+  </composition>
+  
+  <composition name="BeamPipe2Inner" envelope="BPI2">
+    <posXYZ volume="photonBeamHarp" X_Y_Z="0.0 0.0 -27.38" />
+  </composition>
+  
+  <composition name="photonBeamHarp">
+    <posXYZ volume="PSCV" />
+    <posXYZ volume="PSCH" />
+  </composition>
+
+  <tubs name="BPO2" Rio_Z="0.0  2.54   118.767" material="Iron" />
+  <tubs name="BPI2" Rio_Z="0.0  2.38   118.767" material="Vacuum" />
+    
+  <composition name="PairSpecConverter" envelope="PSCM">
+    <posXYZ volume="PSCV"/>
+    <posXYZ volume="PSCH"/>
+  </composition>
+  
+  <tubs name="PSCM" Rio_Z="0.0 2.38 0.53" material="Vacuum"/>
+  <tubs name="PSCV" Rio_Z="0.0 1.143 0.01" material="Aluminum"/>
+  <tubs name="PSCH" Rio_Z="1.143 2.38 0.53" material="Iron"/>
+
+  <tubs name="DET1" Rio_Z="0.   50.  2." material="Air" />
+  <box name="DET2" X_Y_Z=" 450. 270. 0.1" material="Vacuum" />
+  <box name="DET3" X_Y_Z=" 450. 2. 918." material="Air" />
+
+  
+<!-- The composition 'beamPipe' extends the vacuum from the pair 
+     spectrometer to the position of the target.
+
+     Origin of beamPipe is center of the hall.
+-->
+
+  <composition name="beamPipe">
+<!--    <posXYZ volume="DET4"     X_Y_Z="  0.0     0.0 -1400.0"/> -->
+    <posXYZ volume="DET5"     X_Y_Z="  0.0     0.0  1400.0"/> 
+    <posXYZ volume="TAC1" X_Y_Z="150.0  -350.0  1225.0" />  
+    <posXYZ volume="DarkWindow" X_Y_Z="  150.0  -350.0  320.0" />
+    <posXYZ volume="PlatformPipe" X_Y_Z="150.0  -350.0  650."/>
+    <posXYZ volume="PlexWindow" X_Y_Z="150.0  -350.0  830."/>
+    <posXYZ volume="IntMonitor" X_Y_Z="150.0  -350.0  834."/>
+    <posXYZ volume="DET6"     X_Y_Z="  0.0   600.0     0.0"/>
+    <!--posXYZ volume="DET7"     X_Y_Z="  0.0     0.0  -705.0"/--> 
+    <posXYZ volume="HallBellows" X_Y_Z="150.0 -350.0 -1223.287"/>
+    <posXYZ volume="HallPipe" X_Y_Z="150.0  -350.0  -1026.77"/>
+    <!-- Plastic scintillator for beam diagonistics -->
+    <!--posXYZ volume="DET8" X_Y_Z="150 -350.0 -834.0 "/-->
+  </composition>
+
+  <composition name="DarkWindow">
+    <posXYZ volume="DBOW" X_Y_Z="  0.0  0.0  0.0" />
+    <posXYZ volume="DBEW" X_Y_Z="  0.0  0.0  0.0" />
+  </composition>
+
+  <tubs name="DBOW" Rio_Z="20.0  60.0  0.3"  material="Aluminum"/>
+  <tubs name="DBEW" Rio_Z="0.0   20.0  0.01" material="Tedlar"/>
+
+  <composition name="PlatformPipe">
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0  -176.5127" />
+    <posXYZ volume="PipeSection" X_Y_Z="0.0 0.0 0.0" />
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0   176.5127" />
+  </composition>
+
+  <tubs name="PPWD" Rio_Z="0.0   20.32  0.0254" material="Kapton" />
+
+  <composition name="PipeSection" envelope="PPOV">
+    <posXYZ volume="PPIV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PPOV" Rio_Z="0.0   20.32  353.0" material="Iron" />
+  <tubs name="PPIV" Rio_Z="0.0   20.04  353.0" material="Vacuum" />
+
+  <composition name="PlexWindow">
+    <posXYZ volume="PPPW" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="IntMonitor" >
+    <posXYZ volume="INTM" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box  name="INTM" X_Y_Z="2  6  1" material="Scintillator"  />
+
+  <tubs name="PPPW" Rio_Z="0.0   20.32  0.3" material="Plexiglas" />
+
+  <box  name="TAC1" X_Y_Z="20  20  45" material="leadGlassF800" sensitive="true" />
+
+
+  <box name="DET4" X_Y_Z="1700.0  1200.0  2.0" material="Vacuum" />
+  <box name="DET5" X_Y_Z="1700.0  1198.0  2.0" material="Air" />
+  <box name="DET6" X_Y_Z="1700.0  2.0  3000.0" material="Air" />
+  <!--box name="DET7" X_Y_Z="1700.0  1198.0  2.0" material="Air" /-->
+  <tubs name="DET7" Rio_Z="0.0 1.7399  2.0" material="Vacuum"
+        comment="disk detector inside beam pipe at target entrance" />
+  <box name="DET8" X_Y_Z="10.0 10.0 1.0" material="Scintillator" sensitive="true"/>
+
+<!-- Hall bellows -->
+<composition name="HallBellows" envelope="BLWO">
+  <posXYZ volume="BLWI" X_Y_Z="0.0 0.0 -3.5011"/>
+</composition>
+
+<pcon name="BLWO" material="Iron">
+  <polyplane Rio_Z="0.0 1.90500 -13.4"/>
+  <polyplane Rio_Z="0.0 1.90500 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 6.3978"/>
+</pcon>
+
+<tubs name="BLWI" Rio_Z="0. 1.7399 19.7978" material="Vacuum"/>
+
+<!-- Hall Pipe -->
+  <composition name="HallPipe" envelope="OHPI" >
+    <!--posXYZ volume="IHPI" X_Y_Z="0 0 98.6305"/-->
+    <posXYZ volume="InnerHallPipe" X_Y_Z="0.0 0.0 98.6305"/> 
+  </composition>
+
+  <composition name="InnerHallPipe" envelope="IHPI">
+    <posXYZ volume="DET7" X_Y_Z="0 0 280.0"/> 
+    <!--posXYZ volume="CAP1" X_Y_Z="0.0  0.0  190.11265" /-->
+  </composition>
+
+
+  <pcon name="OHPI" material="Iron">
+    <polyplane Rio_Z="0.0 4.27355 -190.1190"/>
+    <polyplane Rio_Z="0.0 4.27355 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +387.380"/>
+  </pcon>
+
+  <tubs name="IHPI" Rio_Z="0.0  1.7399 577.499" material="Vacuum" />
+  <tubs name="CAP1" Rio_Z="0.0  1.7399 0.0127" material="Kapton"/>
+
+<composition name="SixWayCross" envelope="SWCM">
+  <posXYZ volume="sixWayTube" X_Y_Z="0 0 0"/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0 0." rot="0. 180. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 90. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 270. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="90. 0. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="270. 0. 0."/>
+  <posXYZ volume="sixWayBox" X_Y_Z="0. 0. 0."/> 
+</composition>
+
+<box name="SWCM" X_Y_Z="67.9196 67.9196 67.9196" material="Air"
+     comment="Six-way cross mother volume"/>
+<pcon name="SWCP" material="StainlessSteel" comment="Vacuum pipe for 6-way cross">
+  <polyplane Rio_Z="0. 20.32 20.32"/>
+  <polyplane Rio_Z="0. 20.32 32.258"/>
+  <polyplane Rio_Z="0. 22.504 32.258"/>
+  <polyplane Rio_Z="0. 22.504 33.9598"/>
+</pcon>
+  
+<composition name="sixWayTube" envelope="SWCP">
+  <posXYZ volume="SWC2" X_Y_Z="0.0 0.0 27.1399"/>
+</composition>
+
+<composition name="sixWayBox" envelope="SWCB">
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 -20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 -20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="20.08125 0. 0." rot="0 90 0 "/>
+  <posXYZ volume="SWC1" X_Y_Z="-20.08125 0. 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeMotherVolume" X_Y_Z="0. 0. 0." />
+</composition>
+
+<composition name="coldCubeMotherVolume" envelope="CBXM">
+  <posXYZ volume="CBX1" X_Y_Z="0. -7.712  0."/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.1444"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.3032"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 -12.1444"/>
+  <posXYZ volume="CBXS" X_Y_Z="12.1444 4.28 0."/>
+  <posXYZ volume="CBXS" X_Y_Z="-12.1444 4.28 0."/>
+  <posXYZ volume="coldCubeTopPlate" X_Y_Z="0. 16.272 0." rot="90 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 -11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="11.9856 4.28 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="-11.9856 4.28 0." rot="0 90 0"/>
+</composition>
+
+<composition name="coldCubeBeamPlate" envelope="CBXB">
+  <posXYZ volume="CBH0" X_Y_Z="0. -4.2926 0."/>
+</composition>
+
+<composition name="coldCubeSidePlate" envelope="CBSP">
+  <posXYZ volume="CBH2" X_Y_Z="0. 0. 0."/>
+</composition>
+
+<composition name="coldCubeTopPlate" envelope="CHXT">
+  <posXYZ volume="CBH1" X_Y_Z="0. 0. 0." />
+</composition>
+
+<box name="CBSP" X_Y_Z="23.8124 23.8124 0.15875" material="Copper"/>
+<box name="CHXT" X_Y_Z="24.13 24.13 0.15875" material="Copper"/>
+<tubs name="CBH1" Rio_Z="0. 10.795 0.15875" material="Vacuum"/>
+<tubs name="CBH0" Rio_Z="0 1.27 0.15875" material="Vacuum" 
+      comment="Hole for beam"/>
+<box name="CBH2" X_Y_Z="19.05 19.05 0.15875" material="Vacuum"/>
+<box name="CBXB" X_Y_Z="21.8948 21.8948 0.15875" material="Copper"/>
+<box name="CBXS" X_Y_Z="0.15875 21.8948 21.8948" material="Copper"/>
+<box name="CBX1" X_Y_Z="24.13 0.15875 24.13" material="Copper"/>
+<box name="CBXM" X_Y_Z="39.685 39.685 39.685" material="Vacuum"/>
+<box name="SWCB" X_Y_Z="40.64 40.64 40.64" material="StainlessSteel"/>
+<tubs name="SWC1" Rio_Z="0 19.84248 0.4775" material="Vacuum"/>
+<tubs name="SWC2" Rio_Z="0. 19.84248 13.6398" material="Vacuum"/>
+
+<!-- Approximation for the beam profiler -->
+<box name="PFSC" X_Y_Z="12.8 12.8 0.2" material="Scintillator" sensitive="true"/>
+<box name="PFLD" X_Y_Z="10.0 10.0 0.1" material="Lead"/>
+
+<!-- Following is the definition of the active collimator.  It sits
+     on the upstream end of the primary collimator and acts as an
+     active absorber with segmented detection of the beam intensity.
+-->
+
+  <composition name="ColDetector" envelope="INSU">
+    <posXYZ volume="ColAssemblyFinal" X_Y_Z="0.0 0.0 0.50"/>
+    <posXYZ volume="HOUF" X_Y_Z="0.0  0.0  -1.85"/>
+  </composition>
+
+  <composition name="ColAssemblyFinal" envelope="HOUS">
+    <posXYZ volume="ColAssemblyInitial" X_Y_Z="0.0  0.0  -0.15"/>
+  </composition>
+  
+  <composition name="ColAssemblyInitial" envelope="AIRH">
+    <mposPhi volume="DIV1" ncopy="4" Phi0="0" dPhi="90" R_Z="3.375 0."/>  
+    <mposPhi volume="DIV2" ncopy="4" Phi0="45" dPhi="90"/>  
+    <mposPhi volume="innerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+    <mposPhi volume="outerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+  </composition>
+
+  <tubs name="INSU" Rio_Z="0.25   7.36  4.20" material="BoronNitride"/>
+ 
+  <tubs name="HOUS" Rio_Z="0.25   6.70  3.20" material="Aluminum" />
+ 
+  <tubs name="HOUF" Rio_Z="0.25   6.85  0.50" material="Aluminum"/>
+ 
+  <tubs name="AIRH" Rio_Z="0.25   6.5002  2.9" material="Air" />
+  <box  name="DIV1" X_Y_Z="6.25  0.1  2.9" material="Aluminum" />
+  <tubs name="DIV2" Rio_Z="2.7   2.8  2.9" profile="-42.870 85.740"
+                                           material="Aluminum" />
+
+  <composition name="innerPinCushionWedge" envelope="ACWI">
+    <posXYZ volume="ACBI" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="innerPinCushionRow_1" X_Y_Z="0.276 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_2" X_Y_Z="0.376 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_3" X_Y_Z="0.476 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_4" X_Y_Z="0.576 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_5" X_Y_Z="0.676 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_6" X_Y_Z="0.776 0.0 0.40" />
+  </composition>
+  <composition name="innerPinCushionRow_1" envelope="AIR1">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_2" envelope="AIR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_3" envelope="AIR3">
+    <mposY volume="PIN1" ncopy="5" Y0="-0.20" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_4" envelope="AIR4">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_5" envelope="AIR5">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_6" envelope="AIR6">
+    <mposY volume="PIN1" ncopy="9" Y0="-0.40" dY="0.10" />
+  </composition>
+
+  <composition name="outerPinCushionWedge" envelope="ACWO">
+    <posXYZ volume="ACBO" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 -1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 +1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 -1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 +1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 -1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 +1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 -1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 +1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_5" X_Y_Z="3.025 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_6" X_Y_Z="3.125 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_7" X_Y_Z="3.225 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_8" X_Y_Z="3.325 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_9" X_Y_Z="3.425 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_10" X_Y_Z="3.525 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_11" X_Y_Z="3.625 0.0 0.40" />
+  </composition>
+  <composition name="outerPinCushionRow_1" envelope="AOR1">
+    <posXYZ volume="PIN1" />
+  </composition>
+  <composition name="outerPinCushionRow_2" envelope="AOR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_3" envelope="AOR3">
+    <mposY volume="PIN1" ncopy="6" Y0="-0.25" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_4" envelope="AOR4">
+    <mposY volume="PIN1" ncopy="10" Y0="-0.45" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_5" envelope="AOR5">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_6" envelope="AOR6">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_7" envelope="AOR7">
+    <mposY volume="PIN1" ncopy="37" Y0="-1.80" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_8" envelope="AOR8">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_9" envelope="AOR9">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_10" envelope="AORA">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_11" envelope="AORB">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+
+  <tubs name="ACWI" Rio_Z="0.25 2.5  2.5" profile="-33. 66."
+         material="Air" comment="active collimator inner wedge" />  
+  <tubs name="ACWO" Rio_Z="2.97  6.0  2.5" profile="-33. 66."
+         material="Air" comment="active collimator outer wedge" />  
+  <tubs name="ACBI" Rio_Z="0.25 2.5  0.8" profile="-32. 64."
+         material="SoftTungsten" comment="inner wedge base plate" />  
+  <tubs name="ACBO" Rio_Z="3.0  6.0  0.8" profile="-30. 60."
+         material="SoftTungsten" comment="outer wedge base plate" />  
+
+  <box name="AIR1" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AIR2" X_Y_Z="0.051 0.40 1.7" material="Air" />
+  <box name="AIR3" X_Y_Z="0.051 0.50 1.7" material="Air" />
+  <box name="AIR4" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AIR5" X_Y_Z="0.051 0.80 1.7" material="Air" />
+  <box name="AIR6" X_Y_Z="0.051 0.90 1.7" material="Air" />
+
+  <box name="AOR1" X_Y_Z="0.051 0.10 1.7" material="Air" />
+  <box name="AOR2" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AOR3" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AOR4" X_Y_Z="0.051 1.00 1.7" material="Air" />
+  <box name="AOR5" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR6" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR7" X_Y_Z="0.051 3.70 1.7" material="Air" />
+  <box name="AOR8" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AOR9" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AORA" X_Y_Z="0.051 4.10 1.7" material="Air" />
+  <box name="AORB" X_Y_Z="0.051 4.10 1.7" material="Air" />
+
+  <box name="PIN1" X_Y_Z="0.051 0.051 1.7" material="SoftTungsten" />
+ 
+<!-- Following is the definition of the triplet polarimeter.  It sits
+     just before of the shielding wall at the downstream end of the
+     collimator cave, and contains a retractable pair conversion target
+     called PTAR. Forward pairs are detected in the pair spectrometer.
+-->
+
+<!-- Origin of TripletPolar is the beam axis midpoint
+     of the polarimeter vacuum box, as set by the outside walls. -->
+
+  <composition name="TripletPolar">
+     <apply region="nullBfield"/>
+     <posXYZ volume="tripletPolar" X_Y_Z="1.5 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tripletPolar">
+     <posXYZ volume="tpolEnclosure" />
+     <posXYZ volume="tpolVacuumBoxFlange" X_Y_Z="6.50 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTPT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTPM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTIT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTIM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFT" X_Y_Z="0.0 -7.91 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTFM" X_Y_Z="-4.0 4.0 +7.91" unit_length="in" />
+     <posXYZ volume="PTFF" X_Y_Z="-6.910 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 -8.5" unit_length="in" />
+     <posXYZ volume="PTKM" X_Y_Z="-4.0 4.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKF" X_Y_Z="-7.550 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTDR" X_Y_Z="7.25 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tpolVacuumBox" envelope="PTB0">
+     <posXYZ volume="tpolRailGuide" X_Y_Z="0.375 5.131 -3.380" unit_length="in" />
+     <posXYZ volume="tpolTargetCarrier" X_Y_Z="0.25 2.146 -3.380" rot="0 180 0" unit_length="in" />
+     <posXYZ volume="tpolTargetMotor" X_Y_Z="-1.625 4.1449 -1.6284" unit_length="in" />
+     <posXYZ volume="tpolRecoilDetectorCard" X_Y_Z="-1.625 0.0 -2.0" rot="0 0 22.5" unit_length="in" />
+     <posXYZ volume="PTA1" X_Y_Z="-1.625 0.0 -1.9796" unit_length="in" />
+     <posXYZ volume="PTA2" X_Y_Z="-1.625 0.0 -1.9795" unit_length="in" />
+     <posXYZ volume="PTA3" X_Y_Z="-1.625 0.0 -1.9794" unit_length="in" />
+     <posXYZ volume="PTA4" X_Y_Z="-1.625 0.0 -2.0204" unit_length="in" />
+     <!-- <posXYZ volume="PTA5" X_Y_Z="-1.625 0.0 -3.3651" unit_length="in" /> -->
+     <posXYZ volume="PTMP" X_Y_Z="0.0 5.8125 0.0" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 -5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 -4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="-5.125 5.745 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="-4.625 5.5525 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 -2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="0.4872 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="-3.7372 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="0.4872 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="-3.7372 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="0.4872 5.5 -0.6216" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="-3.7372 5.5 -0.6216" unit_length="in" />
+  </composition>
+
+  <composition name="tpolEnclosure" envelope="PTBO">
+     <posXYZ volume="tpolVacuumBox" X_Y_Z="0.125 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH3" X_Y_Z="-4.0 4.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH6" X_Y_Z="0.0 -6.125 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH5" X_Y_Z="-6.125 0.0 -2.0" rot="0 90 0" unit_length="in" />
+  </composition>
+
+  
+  <tubs name="PTAR" Rio_Z="0.0 0.375 0.0075" material="Vacuum" 
+	comment="polarimeter converter target" /> 
+  
+  
+  <box name="PTBO" X_Y_Z="12.5 12.5 12.5" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube1" />
+  <box name="PTB0" X_Y_Z="12.25 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube2" />
+  <box name="PTB1" X_Y_Z="0.5 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box flange subtraction" />
+  <box name="PTB2" X_Y_Z="0.5 15.0 17.0" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box door flange" />
+  <box name="PTB3" X_Y_Z="9.25 0.988 0.625" material="Aluminum" unit_length="in"
+                   comment="polarimeter rail guide" />
+  <box name="PTB4" X_Y_Z="9.25 0.312 0.125" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail gap subtraction" />
+  <box name="PTB5" X_Y_Z="9.25 0.365 0.375" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail box subtraction" />
+  <box name="PTB6" X_Y_Z="42.0 42.0 2.0" material="Iron" unit_length="mm"
+                   comment="polarimeter motor plate" />
+  <box name="PTB7" X_Y_Z="5.25 5.792 0.118" material="Aluminum" unit_length="in"
+                   comment="polarimeter target holder" />
+  <box name="PTB8" X_Y_Z="4.325 4.292 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter target holder subtraction" />
+  <tubs name="PTH0" Rio_Z="0.0 21.0 69.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motor" />
+  <tubs name="PTH1" Rio_Z="0.0 10.5 32.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motion gear" />
+  <tubs name="PTH2" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter beam hole subtraction" />
+  <tubs name="PTH3" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter motor hole subtraction" />
+  <tubs name="PTH4" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter auxilliary hole subtraction" />
+  <tubs name="PTH5" Rio_Z="0.0 1.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter feed hole subtraction" />
+  <tubs name="PTH6" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter turbo pump hole subtraction" />
+  <tubs name="PTH7" Rio_Z="0.0 0.375 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter converter tray subtraction" />
+
+  <composition name="tpolVacuumBoxFlange" envelope="PTB2">
+     <posXYZ volume="PTB1" />
+  </composition>
+  <composition name="tpolRailGuide" envelope="PTB3">
+     <posXYZ volume="PTB4" X_Y_Z="0.0 -0.338 0.0" unit_length="in" />
+     <posXYZ volume="PTB5" />
+  </composition>
+  <composition name="tpolTargetDisk" envelope="PTH7">
+     <posXYZ volume="PTAR" />
+  </composition>
+  <composition name="tpolTargetCarrier" envelope="PTB7">
+     <posXYZ volume="PTB8" X_Y_Z="0.4625 0.75 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="1.875 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="0.625 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="-0.625 -2.146 0.0" unit_length="in" />
+  </composition>
+  <composition name="tpolTargetMotor">
+     <posXYZ volume="PTH0" />
+     <posXYZ volume="PTB6" X_Y_Z="0.0 0.0 -35.5" unit_length="mm" />
+     <posXYZ volume="PTH1" X_Y_Z="0.0 0.0 -52.5" unit_length="mm" />
+  </composition>
+  
+  <composition name="tpolRecoilDetector" envelope="PTDE">
+     <posXYZ volume="tpolRecoilRing1" />
+     <posXYZ volume="tpolRecoilRing2" />
+     <posXYZ volume="tpolRecoilRing3" />
+     <posXYZ volume="tpolRecoilRing4" />
+     <posXYZ volume="tpolRecoilRing5" />
+     <posXYZ volume="tpolRecoilRing6" />
+     <posXYZ volume="tpolRecoilRing7" />
+     <posXYZ volume="tpolRecoilRing8" />
+     <posXYZ volume="tpolRecoilRing9" />
+     <posXYZ volume="tpolRecoilRing10" />
+     <posXYZ volume="tpolRecoilRing11" />
+     <posXYZ volume="tpolRecoilRing12" />
+     <posXYZ volume="tpolRecoilRing13" />
+     <posXYZ volume="tpolRecoilRing14" />
+     <posXYZ volume="tpolRecoilRing15" />
+     <posXYZ volume="tpolRecoilRing16" />
+     <posXYZ volume="tpolRecoilRing17" />
+     <posXYZ volume="tpolRecoilRing18" />
+     <posXYZ volume="tpolRecoilRing19" />
+     <posXYZ volume="tpolRecoilRing20" />
+     <posXYZ volume="tpolRecoilRing21" />
+     <posXYZ volume="tpolRecoilRing22" />
+     <posXYZ volume="tpolRecoilRing23" />
+     <posXYZ volume="tpolRecoilRing24" />
+  </composition>
+  <tubs name="PTDE" Rio_Z="11.0 35.0 1.5" material="Vacuum" unit_length="mm" 
+                   comment="container for the triplet polarimeter detector" />
+
+  <composition name="tpolRecoilRing1" envelope="PTRA">
+     <mposPhi volume="PTSA" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="1" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing2" envelope="PTRB">
+     <mposPhi volume="PTSB" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="2" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing3" envelope="PTRC">
+     <mposPhi volume="PTSC" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="3" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing4" envelope="PTRD">
+     <mposPhi volume="PTSD" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="4" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing5" envelope="PTRE">
+     <mposPhi volume="PTSE" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="5" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing6" envelope="PTRF">
+     <mposPhi volume="PTSF" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="6" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing7" envelope="PTRG">
+     <mposPhi volume="PTSG" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="7" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing8" envelope="PTRH">
+     <mposPhi volume="PTSH" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="8" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing9" envelope="PTRI">
+     <mposPhi volume="PTSI" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="9" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing10" envelope="PTRJ">
+     <mposPhi volume="PTSJ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="10" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing11" envelope="PTRK">
+     <mposPhi volume="PTSK" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="11" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing12" envelope="PTRL">
+     <mposPhi volume="PTSL" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="12" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing13" envelope="PTRM">
+     <mposPhi volume="PTSM" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="13" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing14" envelope="PTRN">
+     <mposPhi volume="PTSN" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="14" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing15" envelope="PTRO">
+     <mposPhi volume="PTSO" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="15" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing16" envelope="PTRP">
+     <mposPhi volume="PTSP" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="16" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing17" envelope="PTRQ">
+     <mposPhi volume="PTSQ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="17" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing18" envelope="PTRR">
+     <mposPhi volume="PTSR" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="18" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing19" envelope="PTRS">
+     <mposPhi volume="PTSS" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="19" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing20" envelope="PTRT">
+     <mposPhi volume="PTST" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="20" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing21" envelope="PTRU">
+     <mposPhi volume="PTSU" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="21" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing22" envelope="PTRV">
+     <mposPhi volume="PTSV" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="22" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing23" envelope="PTRW">
+     <mposPhi volume="PTSW" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="23" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing24" envelope="PTRX">
+     <mposPhi volume="PTSX" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="24" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+
+  <tubs name="PTRA" Rio_Z="11 12 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRB" Rio_Z="12 13 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRC" Rio_Z="13 14 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRD" Rio_Z="14 15 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRE" Rio_Z="15 16 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRF" Rio_Z="16 17 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRG" Rio_Z="17 18 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRH" Rio_Z="18 19 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRI" Rio_Z="19 20 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRJ" Rio_Z="20 21 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRK" Rio_Z="21 22 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRL" Rio_Z="22 23 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRM" Rio_Z="23 24 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRN" Rio_Z="24 25 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRO" Rio_Z="25 26 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRP" Rio_Z="26 27 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRQ" Rio_Z="27 28 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRR" Rio_Z="28 29 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRS" Rio_Z="29 30 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRT" Rio_Z="30 31 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRU" Rio_Z="31 32 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRV" Rio_Z="32 33 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRW" Rio_Z="33 34 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRX" Rio_Z="34 35 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTSA" Rio_Z="11 12 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSB" Rio_Z="12 13 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSC" Rio_Z="13 14 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSD" Rio_Z="14 15 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSE" Rio_Z="15 16 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSF" Rio_Z="16 17 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSG" Rio_Z="17 18 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSH" Rio_Z="18 19 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSI" Rio_Z="19 20 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSJ" Rio_Z="20 21 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSK" Rio_Z="21 22 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSL" Rio_Z="22 23 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSM" Rio_Z="23 24 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSN" Rio_Z="24 25 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSO" Rio_Z="25 26 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSP" Rio_Z="26 27 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSQ" Rio_Z="27 28 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSR" Rio_Z="28 29 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSS" Rio_Z="29 30 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTST" Rio_Z="30 31 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSU" Rio_Z="31 32 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSV" Rio_Z="32 33 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSW" Rio_Z="33 34 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSX" Rio_Z="34 35 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+
+  <tubs name="PTA1" Rio_Z="11 35 0.0006" material="Aluminum" unit_length="mm"
+                    comment="called blank1, whatever that is" />
+  <tubs name="PTA2" Rio_Z="11 35 0.0035" material="Silicon" unit_length="mm" 
+                    comment="called blank2, whatever that is" />
+  <tubs name="PTA3" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank3, whatever that is" />
+  <tubs name="PTA4" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank4, whatever that is" />
+  <tubs name="PTA5" Rio_Z="0.0 9.525 0.5" material="Vacuum" unit_length="mm"
+                    comment="called blank5, whatever that is" />
+
+  <composition name="tpolRecoilDetectorCard" envelope="PTCA">
+     <posXYZ volume="tpolRecoilDetector" />
+     <posXYZ volume="PTCH" />
+  </composition>
+
+  <pgon name="PTCA" segments="8" material="FR-4" unit_length="mm"
+                   comment="card that carries the recoil polarimeter detector">
+     <polyplane Rio_Z="0 60 -0.75" unit_length="mm" />
+     <polyplane Rio_Z="0 60 0.75" unit_length="mm" />
+  </pgon>
+  <tubs name="PTCH" Rio_Z="0.0 11.0 1.5" material="Vacuum" unit_length="mm"
+                   comment="central hole through the polarimeter card" />
+  
+  <tubs name="PTPB" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="beam pipe to the upstream/downstream" />
+  <tubs name="PTIB" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="beam vacuum to the upstream/downstream" />
+  <tubs name="PTPF" Rio_Z="1.9375 2.0 1.05" material="Iron" unit_length="in"
+                   comment="feed pipe to the side" />
+  <tubs name="PTIF" Rio_Z="0.0 1.9375 1.05" material="Vacuum" unit_length="in"
+                   comment="feed vacuum to the side" />
+  <tubs name="PTPT" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe" />
+  <tubs name="PTIT" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="turbo pump port vacuum" />
+  <tubs name="PTPM" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="motor port pipe" />
+  <tubs name="PTIM" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="motor port vacuum" />
+  <tubs name="PTPX" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="aux port pipe" />
+  <tubs name="PTIX" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="aux port vacuum" />
+  <tubs name="PTFB" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="beam pipe flange to the upstream/downstream" />
+  <tubs name="PTFX" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="aux port pipe flange" />
+  <tubs name="PTFT" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe flange" />
+  <tubs name="PTFM" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="motor port pipe flange" />
+  <tubs name="PTFF" Rio_Z="2.0 3.0 0.78" material="Iron" unit_length="in"
+                   comment="feed pipe flange" />
+  <tubs name="PTKX" Rio_Z="0.0 1.6875 0.5" material="Iron" unit_length="in"
+                   comment="aux port pipe cap" />
+  <tubs name="PTKM" Rio_Z="0.0 2.250 0.5" material="Iron" unit_length="in"
+                   comment="motor port pipe cap" />
+  <tubs name="PTKF" Rio_Z="0.0 3.0 0.5" material="Iron" unit_length="in"
+                   comment="feed pipe cap" />
+
+  <box name="PTMP" X_Y_Z="10.0 0.375 10.0" material="Aluminum" unit_length="in"
+                   comment="mounting plate" />
+  <box name="PTVR" X_Y_Z="6.0 0.51 0.25" material="Iron" unit_length="in"
+                   comment="vertical rack piece" />
+  <box name="PTHR" X_Y_Z="6.0 0.125 0.75" material="Iron" unit_length="in"
+                   comment="horizontal rack piece" />
+  <box name="PTBR" X_Y_Z="4.75 0.50 0.0625" material="Aluminum" unit_length="in"
+                   comment="horizontal bar piece" />
+  <box name="PTLG" X_Y_Z="0.5 7.987 0.125" material="Aluminum" unit_length="in"
+                   comment="support leg" />
+  <box name="PTVS" X_Y_Z="0.5 2.5 0.25" material="Aluminum" unit_length="in"
+                   comment="vertical support piece" />
+  <box name="PTHS" X_Y_Z="0.5 0.25 2.5" material="Aluminum" unit_length="in"
+                   comment="horizontal support piece" />
+  <box name="PTDR" X_Y_Z="1.0 15.0 17.0" material="Aluminum" unit_length="in"
+                   comment="vacuum box door" />
+
+  <!-- there is no mcfast model of the photon beamline -->
+
+</section>
+
+<!-- </HDDS> -->

--- a/BeamLine_HDDS_50_75.xml
+++ b/BeamLine_HDDS_50_75.xml
@@ -1,0 +1,1642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DOCTYPE HDDS>
+
+  Hall D Geometry Data Base: Beam Line
+  ************************************
+
+     version 1.0: Initial version	-rtj
+
+     Revision 1.1 10/18/2002 
+     -added concrete shielding to the collimator housing 
+     -added the virtual detectors to this code:
+        DET1: disk intercepting entire beam upstream of collimators
+        DET2: plane perpendicular to beam just after second collimator
+        DET3: plane mounted just below the ceiling of collimator cave
+        DET4: plane perpendicular to beam just after entry to hall
+        DET5: plane perpendicular to beam at photon dump end of hall
+        DET6: plane mounted just below the ceiling inside the hall
+        DET7: plane perpendicular to beam just before the target
+     -added a steel tube containing a vacuum that goes from the back of
+      the collimator to the front of the solenoid  
+     -csg-
+
+     Revision 1.2 10/28/2002
+     -revised collimator to the heavy shielding option 
+     -added a steel tube containing a vacuum in the WALL, SHLD and ABS2 volumes
+     -repositioned DET3 to be inside the collimator housing 
+     -removed the BEAM volume from the collimator system
+     -csg-
+
+     Revision 1.3 1/9/2003
+     -shrunk the size of the vacuum tube from r=5.3 to r=2.5 in order to
+      extend the tube into the second steering magnet
+     -csg-
+
+     Revision 1.4 06/16/2003
+     -mid-shielding option
+     -modified DET1, now a cylinder placed in front of primary collimator
+     -added tungsten pin-cushion detector model into simulation
+     -csg- 
+
+     Revision 2.0 05/16/2008
+     -moved DET2 to just after the second collimator, in agreement with
+      the comments below.  Somehow it got misplaced to upstream of the
+      second collimator.  I guess no one was using it until now.
+     -added the volume CONV for the pair conversion target located inside
+      the vacuum pipe just downstream of the second sweep magnet.  Right
+      now it its material is vacuum, but the thickness of 240 microns is
+      chosen to make a 0.1% converter if the material is set to Carbon.
+
+
+     Revision 2.1  12/12/2008, A.S., rtj
+       Made the following changes in the composition 'collimatorStack':
+  	  1. Added the composition BeamPipe0 describing a vacuum beam pipe at the entrance 
+             of the collimator cave:
+              - the beam pipe radius is 12.4 cm
+              - the exit window: 250 micron Kapton with the radius of 10.14 cm. 
+ 	  2. Moved the active collimator, DET1, and other components 83.96 cm upstream the 
+             beamline.
+          3. Changed layout of the 1st passive collimator to a composite W/Pb:
+	      - the inner part is a W  box,  5.08 x  5.08 x 20.0 cm3
+              - the outer part is a Pb box, 30.48 x 30.48 x 20.0 cm3 
+          4. Added  the vacuum beam pipe (Flange1 compositon) in front of the 1st sweeping 
+             magnet:
+              - use 150 micron Kapton entrance window
+              - vaccuum goes all the way downstream the beamline until the GlueX detector.
+          5. Modified the layout of the 1st sweeping magnet:
+              - the outer dimensions are 29.2 x 24.8 x 355.6 cm3
+              - the gap size is 10.22 x 4.9 cm2 
+              - the field inside the gap is 0.23 T (integrated field is 0.82 Tm)
+              - the elliptical vacuum pipe goes through the magnet. The semi-axes of the pipe 
+              are 4.95 cm and 2.29 cm.        
+          6. Added the concrete blocks around the 1st sweeping magnet, composition ConcreteWall1. 
+             The size of the wall is 101.6 x 147.32 x 121.92 cm3.
+          7. Added the composition Flange2 to connect the 1st sweeping magnet with a vacuum chamber.
+          8. Added a vacuum chamber after the 1st sweeping magnet with the following dimensions:
+              - 50.8 cm long tube with the inner and outer radii of Rin = 9.83 cm and Rout = 9.85.
+          9. Added the small lead wall after the vacuum chamber, composition LeadBand1.
+         10. Added the composition Flange3 to connect the vacuum pipe between the lead band and the
+             2nd collimatoor.
+         11. Changed material of the 2nd collimator from Nickel to Iron. The default pinhole 
+             diameter was changed from 1 cm to 0.6 cm.
+         12. Added the composition Flange4 to connect the vacuum pipe between the 2nd collimator and
+             the 2nd sweeping magnet.
+         13. Changed the layout of the second sweeping magnet:
+              - outer dimensions are 42 x 20.8 cm2
+              - the gap size is 20.3 x 5 cm2, the field in the gap is 0.23 T
+              - 1.75 cm radius vacuum beam pipe goes through the magnet.         
+         14. Added the composition Flange5 to connect 2nd the sweeping magnet with the vacuum beam 
+             pipe.           
+         15. Added a 1m long vacuum beam pipe. The inner and outer radii are 2.38 and 2.54 cm, 
+             respectively.
+         16. Added the small lead wall (composition LeadBand2), 81.28 x 20.32 x 10.16 cm3.
+         17. Placed the vertical plane DET2 after the lead wall. 
+         18. Added the composition Flange6 to connect the vacuum pipe between the lead wall and 
+             a pair spectrometer converter box.          
+         19. Added the pair spectrometer converter. The converter thickness and material can be set
+             in the box 'PTAR'   <box  name="PTAR" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />.
+         20. Added the composition Flange7 to connect the vacuum pipe between the converter and 
+             the concrete wall.
+         21. Modified the size of the concrete shielding wall to 450.0 x 270.0 x 121.92 cm3.
+             Added passage to the collimator cave.
+         22. Decreased thickness of the lead wall to 5.08 cm (size of the lead brick).
+              
+     Revision 2.2  12/22/2008
+       Modified the composition 'beamPipe'. Now 'beamPipe' extends the vacuum from the 
+       pair spectrometer to the position of the target.
+
+     Revision 3.0  3/2/2011
+       Large group of revisions, to reflect the beamline geometry and shielding
+       in the engineering drawings for the cave, and the new pair spectrometer.
+
+     Revision 3.1 9/6/2013
+       Updates for compatibility with geant4 -rtj
+       a) Many small shifts to various volumes to eliminate overlaps.
+       b) Changes to dimensions of the active collimator wedges, and even
+          the number of pins per row, so that all overlaps are eliminated.
+
+     Revision 3.2 12/12/2016
+       Updates to introduce the triplet polarimeter -rtj
+       a) renamed downstream PS converter target from PTAR to CONV
+       b) reserved the name PTAR for the triplet polarimeter target
+       c) incorporated a detailed geometric model of the triplet polarimeter
+          from the ASU group into the beamline geometry
+
+     Revision 3.3 3/27/2017
+     Added TAC and some material downstream the FCAL - A.S. 
+     - FCAL dark box window, FCAL platform pipe with plexiglass window, beam 
+     - intensity monitor, and TAC
+
+
+
+<HDDS specification="v1.0" xmlns="http://www.gluex.org/hdds">
+-->
+
+<section name        = "BeamLine"
+         version     = "3.2"
+         date        = "2016-12-12"
+         author      = "R.T. Jones"
+         top_volume  = "collimatorPackage"
+         specification = "v1.0">
+
+<!-- Origin of collimatorPackage is center of the entrance face of the
+     primary collimator.  					-->
+
+  <composition name="collimatorPackage">
+    <posXYZ volume="ShieldedCollimator" X_Y_Z="0.0  0.0  400.0" />
+  </composition>
+
+  <box name="SHLD" X_Y_Z="550.  550.  1300." material="Concrete"/>
+  <composition name="ShieldedCollimator" envelope="SHLD">
+    <posXYZ volume="pipeFromTaggerHall" X_Y_Z="0.0  0.0  -625.0" />
+    <posXYZ volume="collimatorCave" X_Y_Z="0.0  35.0  25.0" />
+  </composition>  
+ 
+  <box  name="CAVE" X_Y_Z="450. 270. 1250." material="Air" />
+  <composition name="collimatorCave" envelope="CAVE">
+    <posXYZ volume="collimatorStack" X_Y_Z="0.0 -35.0 -500.0"/>     
+<!--  <posXYZ volume="DET2" X_Y_Z="0.0  0.0  225.0" /> -->
+    <posXYZ volume="DET3" X_Y_Z="0.0  132.0  0.0" />
+  </composition>
+ 
+  <composition name="collimatorSubCave">
+    <posXYZ volume="collimatorStack" />
+  </composition>
+
+  <composition name="collimatorStack">
+    <posXYZ volume="BeamPipe0"     X_Y_Z="0.0  0.0  -125.0"  />
+    <!--posXYZ volume="PFLD"          X_Y_Z="0.0  0.0  -99.0"  />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -97.0"   />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -93.0"   /-->
+    <posXYZ volume="DET1"          X_Y_Z="0.0  0.0  -49.46"  />
+    <posXYZ volume="ColDetector"   X_Y_Z="0.0  0.0  -46.16"  />
+    <posXYZ volume="PrimaryCol"    X_Y_Z="0.0  0.0  -33.96"  />
+    <posXYZ volume="Flange1"       X_Y_Z="0.0  0.0   11.52"  />
+    <posXYZ volume="sweepMagnet1"  X_Y_Z="0.0  0.0   189.32" />
+    <posXYZ volume="ConcreteWall1" X_Y_Z="0.0  0.0   107.96" />
+    <posXYZ volume="Flange2"       X_Y_Z="0.0  0.0   367.12" />
+    <posXYZ volume="VacuumChamber" X_Y_Z="0.0  0.0   426.54" />
+    <posXYZ volume="LeadBand1"     X_Y_Z="0.0  0.0   457.02" />
+    <posXYZ volume="Flange3"       X_Y_Z="0.0  0.0   462.10" />
+    <posXYZ volume="COL2"          X_Y_Z="0.0  0.0   555.04" />
+    <posXYZ volume="Flange4"       X_Y_Z="0.0  0.0   580.44" />
+    <posXYZ volume="sweepMagnet2"  X_Y_Z="0.0  0.0   630.28" />
+    <posXYZ volume="Flange5"       X_Y_Z="0.0  0.0   648.28" />
+    <posXYZ volume="BeamPipe1"     X_Y_Z="0.0  0.0   712.28" />
+    <posXYZ volume="LeadBand2"     X_Y_Z="0.0  0.0   743.52" />
+    <posXYZ volume="DET2"          X_Y_Z="0.0  35.0  748.65" /> 
+    <posXYZ volume="Flange6"       X_Y_Z="0.0  0.0   748.70" />
+    <posXYZ volume="TripletPolar"  X_Y_Z="0.0 0.0    820.00" />
+    <posXYZ volume="Flange7"       X_Y_Z="0.0  0.0   840.954" />
+    <posXYZ volume="ConcreteWall2" X_Y_Z="0.0  33.0  941.24" />
+    <posXYZ volume="shieldingWall" X_Y_Z="0.0  35.0 1004.74" />     
+    <!--    <posXYZ volume="TargetBox"     X_Y_Z="0.0  0.0 1085.00" />   -->
+    <posXYZ volume="BeamPipe2"     X_Y_Z="0.0  0.0  1066.668" /> 
+  </composition>
+  
+<!-- Beam Pipe 0 -->
+
+  <composition name="pipeFromTaggerHall" envelope="PFTH">
+    <posXYZ volume="PFTV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PFTH" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="PFTV" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipe0">
+    <posXYZ volume="BeamPipeTube"    X_Y_Z="0.0  0.0  25.0" />
+    <posXYZ volume="BeamPipeFlange1" X_Y_Z="0.0  0.0  48.58" />
+    <posXYZ volume="BeamPipeExitWindow" X_Y_Z="0.0  0.0  50.0" />
+    <posXYZ volume="BeamPipeFlange2" X_Y_Z="0.0  0.0  51.42"  />
+  </composition>
+
+  <composition name="BeamPipeTube" envelope="BPTO">
+    <posXYZ volume="BPTI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPTO" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="BPTI" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipeFlange1">
+    <posXYZ volume="BFO1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BFO1" Rio_Z="12.7   15.24  2.84" material="Iron" />
+
+  <composition name="BeamPipeExitWindow">
+    <posXYZ volume="FCAP" X_Y_Z="0.0  0.0  0.0125"/>
+  </composition>
+
+  <tubs name="FCAP" Rio_Z="0.0   10.16   0.025" material="Kapton" />
+
+  <composition name="BeamPipeFlange2">
+    <posXYZ volume="BFO2" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="BFO2" Rio_Z="10.16   15.24   2.84"  material="Iron" />
+
+
+<!-- Primary Collimator -->
+
+  <composition name="PrimaryCol" envelope="PCPB">
+    <posXYZ volume="TungstenInsert" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="PCPB"  X_Y_Z="30.48  30.48  20." material="Lead" />
+
+  <composition name="TungstenInsert" envelope="PCTT">
+    <posXYZ volume="PCTH" X_Y_Z="0.0 0.0 0.0" />
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.02865 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.05730 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.11459 0 0" /-->
+  </composition>
+  <composition name="PrimaryCollimatorAperture" envelope="PCTH">
+    <posXYZ volume="PCTI" X_Y_Z="0.0 0.0 -5.0" />
+  </composition>
+
+  <box  name="PCTT"  X_Y_Z="5.08   5.08   20." material="Tungsten" />
+  <!--tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" /-->
+  <tubs name="PCTH"  Rio_Z="0.0    0.25   20." material="Air" />
+  <tubs name="PCTI"  Rio_Z="0.05   0.25   10." material="Tungsten" 
+        comment="pin-hole insert for reduced intensity running" />
+
+
+<!-- Flange 1 -->
+
+  <composition name="Flange1">
+    <posXYZ volume="FlangeOneDisk" X_Y_Z="0.0  0.0  -7.72" />
+    <posXYZ volume="FlangeOneWindow" X_Y_Z="0.0  0.0  -6.65" />
+    <posXYZ volume="FlangeOnePipe" X_Y_Z="0.0  0.0  -3.325" />
+  </composition>
+
+  <composition name="FlangeOneDisk">
+    <posXYZ volume="FOI1" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="FOI1" Rio_Z="1.27  8.57  2.14"  material="Iron" />
+
+  <composition name="FlangeOneWindow">
+    <posXYZ volume="F1CP" X_Y_Z="0.0  0.0  -0.0075"/>
+  </composition>
+
+  <tubs name="F1CP" Rio_Z="0.0   1.27  0.015" material="Kapton" />
+
+  <composition name="FlangeOnePipe" envelope="FOPO">
+    <posXYZ volume="FOPI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FOPO" Rxy_Z="5.11  2.45   6.65" material="Iron" />
+  <eltu name="FOPI" Rxy_Z="4.95  2.29   6.65" material="Vacuum" />
+
+
+<!-- 1st Sweeping Magnet -->
+
+  <composition name="sweepMagnet1" envelope="MAG1">
+    <posXYZ volume="POL1" X_Y_Z="0.0 +7.425 0.0" />
+    <posXYZ volume="POL1" X_Y_Z="0.0 -7.425 0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="-9.855 0.0  0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="+9.855 0.0  0.0" />
+    <posXYZ volume="MagnetPipe1" X_Y_Z="0.0  0.0  0.0" />
+  </composition> 
+
+  <box name="MAG1" X_Y_Z="29.2 24.8 355.6" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <box name="POL1" X_Y_Z="29.2  9.95  355.6" material="Iron" />
+  <box name="GAP1" X_Y_Z="9.49  4.9   355.6" material="Iron" />
+
+  <composition name="MagnetPipe1" envelope="MPO1">
+    <posXYZ volume="MPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="MPO1" Rxy_Z="5.11  2.45  355.6" material="Iron" />
+  <eltu name="MPI1" Rxy_Z="4.95  2.29  355.6" material="Vacuum" />
+
+
+<!-- Concrete Wall around the 1st sweeping magnet -->
+
+  <composition name="ConcreteWall1">
+    <posXYZ volume="WTOP" X_Y_Z="0.0   +30.3  0.0" />
+    <posXYZ volume="WBOT" X_Y_Z="0.0   -56.2  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="+32.7   0.0  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="-32.7   0.0  0.0" />
+  </composition> 
+
+  <box name="WTOP" X_Y_Z="101.6  35.8  121.92" material="Concrete" />
+  <box name="WBOT" X_Y_Z="101.6  87.6  121.92" material="Concrete" />
+  <box name="WSID" X_Y_Z="36.2   24.8  121.92" material="Concrete" />
+
+
+<!-- Flange 2 -->
+
+  <composition name="Flange2">
+    <posXYZ volume="FlangeTwoDisk1" X_Y_Z="0.0  0.0  2.29" />
+    <posXYZ volume="FlangeTwoDisk2" X_Y_Z="0.0  0.0  6.72"/>
+    <posXYZ volume="FlangeTwoDisk3" X_Y_Z="0.0  0.0  16.88"/>
+    <posXYZ volume="FlangeTwoDisk4" X_Y_Z="0.0  0.0  27.04"/>
+    <posXYZ volume="FlangeTwoDisk5" X_Y_Z="0.0  0.0  31.6"/>
+  </composition>
+
+  <composition name="FlangeTwoDisk1" envelope="FTO1">
+    <posXYZ volume="FTI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FTO1" Rxy_Z="5.11  2.45   4.58" material="Iron" />
+  <eltu name="FTI1" Rxy_Z="4.95  2.29   4.58" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk2" envelope="FTO2">
+    <posXYZ volume="FTI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO2" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI2" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk3" envelope="FTO3">
+    <posXYZ volume="FTI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO3" Rio_Z="0.0  6.21  16.04" material="Iron" />   
+  <tubs name="FTI3" Rio_Z="0.0  6.19  16.04" material="Vacuum" /> 
+
+  <composition name="FlangeTwoDisk4" envelope="FTO4">
+    <posXYZ volume="FTI4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO4" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI4" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk5" envelope="FTO5">
+    <posXYZ volume="FTI5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO5" Rio_Z="0.0  6.35   4.84" material="Iron" />
+  <tubs name="FTI5" Rio_Z="0.0  6.19   4.84" material="Vacuum" />
+
+
+<!-- Vacuum chamber after the 1st sweeping magnet-->
+
+  <composition name="VacuumChamber">
+    <posXYZ volume="VacuumChambDisk1" X_Y_Z="0.0 0.0 -25.30"/>
+    <posXYZ volume="VacuumChambDisk2" X_Y_Z="0.0 0.0  0.0"/>
+    <posXYZ volume="VacuumChambDisk3" X_Y_Z="0.0 0.0  25.30"/>
+  </composition>
+
+  <composition name="VacuumChambDisk1" envelope="VCO1">
+    <posXYZ volume="VCI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO1" Rio_Z="0.0  9.85   0.2" material="Iron" />
+  <tubs name="VCI1" Rio_Z="0.0  6.19   0.2" material="Vacuum" />
+
+  <composition name="VacuumChambDisk2" envelope="VCO2">
+    <posXYZ volume="VCI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO2" Rio_Z="0.0  9.85  50.40" material="Iron" />
+  <tubs name="VCI2" Rio_Z="0.0  9.83  50.40" material="Vacuum" />
+
+  <composition name="VacuumChambDisk3" envelope="VCO3">
+    <posXYZ volume="VCI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO3" Rio_Z="0.0  9.85  0.2" material="Iron" />
+  <tubs name="VCI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+
+<!-- Lead Band 1 -->
+
+  <composition name="LeadBand1" envelope="LBD1">
+    <posXYZ volume="LeadBandPipe1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe1" envelope="LBO1">
+    <posXYZ volume="LBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD1" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO1" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI1" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 3 -->
+
+  <composition name="Flange3">
+    <posXYZ volume="FlangeThreeDisk1" X_Y_Z="0.0  0.0  24.56" />
+    <posXYZ volume="FlangeThreeDisk2" X_Y_Z="0.0  0.0  50.70"/>
+    <posXYZ volume="FlangeThreeDisk3" X_Y_Z="0.0  0.0  55.78"/>
+    <posXYZ volume="FlangeThreeDisk4" X_Y_Z="0.0  0.0  60.86"/>
+    <posXYZ volume="FlangeThreeDisk5" X_Y_Z="0.0  0.0  64.99"/>
+  </composition>
+
+  <composition name="FlangeThreeDisk1" envelope="F3O1">
+    <posXYZ volume="F3I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O1" Rio_Z="0.0  2.54  49.12" material="Iron" />
+  <tubs name="F3I1" Rio_Z="0.0  2.38  49.12" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk2" envelope="F3O2">
+    <posXYZ volume="F3I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk3" envelope="F3O3">
+    <posXYZ volume="F3I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F3I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk4" envelope="F3O4">
+    <posXYZ volume="F3I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk5" envelope="F3O5">
+    <posXYZ volume="F3I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O5" Rio_Z="0.0  2.54   5.1" material="Iron" />
+  <tubs name="F3I5" Rio_Z="0.0  2.38   5.1" material="Vacuum" />
+
+
+<!-- 2nd Collimator -->
+
+  <composition name="COL2" envelope="OCOL">
+    <posXYZ volume="ICOL" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="OCOL" Rio_Z="0.0  10.0  50.8" material="Iron" />
+  <tubs name="ICOL" Rio_Z="0.0   0.5  50.8" material="Vacuum" />
+
+<!-- Flange 4 -->
+
+  <composition name="Flange4">
+    <posXYZ volume="FlangeFourDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFourDisk2" X_Y_Z="0.0  0.0  9.84"/>
+    <posXYZ volume="FlangeFourDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFourDisk4" X_Y_Z="0.0  0.0  20.0"/>
+    <posXYZ volume="FlangeFourDisk5" X_Y_Z="0.0  0.0  26.71"/>
+  </composition>
+
+  <composition name="FlangeFourDisk1" envelope="F4O1">
+    <posXYZ volume="F4I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F4I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+
+  <composition name="FlangeFourDisk2" envelope="F4O2">
+    <posXYZ volume="F4I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk3" envelope="F4O3">
+    <posXYZ volume="F4I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F4I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFourDisk4" envelope="F4O4">
+    <posXYZ volume="F4I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I4" Rio_Z="0.0  1.745  3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk5" envelope="F4O5">
+    <posXYZ volume="F4I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O5" Rio_Z="0.0  1.905   10.26" material="Iron" />
+  <tubs name="F4I5" Rio_Z="0.0  1.745   10.26" material="Vacuum" />
+
+
+<!-- 2nd Sweeping Magnet -->
+
+  <composition name="sweepMagnet2">
+    <posXYZ volume="Core" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Core" envelope="POL2">
+    <posXYZ volume="Aperture" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Aperture" envelope="GAP2">
+    <posXYZ volume="MagnetPipe2" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="POL2" X_Y_Z="42.0  20.8  36.0" material="Iron" />
+  <box name="GAP2" X_Y_Z="20.3   5.0  36.0" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <composition name="MagnetPipe2" envelope="MPO2">
+    <posXYZ volume="MPI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="MPO2" Rio_Z="0.0  1.905  36.0" material="Iron" />
+  <tubs name="MPI2" Rio_Z="0.0  1.745  36.0" material="Vacuum" />
+
+
+<!-- Flange 5 -->
+
+  <composition name="Flange5">
+    <posXYZ volume="FlangeFiveDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFiveDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeFiveDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFiveDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeFiveDisk5" X_Y_Z="0.0  0.0  29.71"/>
+  </composition>
+
+  <composition name="FlangeFiveDisk1" envelope="F5O1">
+    <posXYZ volume="F5I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O1" Rio_Z="0.0  1.905  8.26" material="Iron" />
+  <tubs name="F5I1" Rio_Z="0.0  1.745  8.26" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk2" envelope="F5O2">
+    <posXYZ volume="F5I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk3" envelope="F5O3">
+    <posXYZ volume="F5I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F5I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk4" envelope="F5O4">
+    <posXYZ volume="F5I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk5" envelope="F5O5">
+    <posXYZ volume="F5I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O5" Rio_Z="0.0  2.54  16.26" material="Iron" />
+  <tubs name="F5I5" Rio_Z="0.0  2.38  16.26" material="Vacuum" />
+
+
+<!-- Beam Pipe1 -->
+
+  <composition name="BeamPipe1" envelope="BPO1">
+    <posXYZ volume="BPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPO1" Rio_Z="0.0  2.54  52.32" material="Iron" />
+  <tubs name="BPI1" Rio_Z="0.0  2.38  52.32" material="Vacuum" />
+
+<!-- Lead Band 2 -->
+
+  <composition name="LeadBand2" envelope="LBD2">
+    <posXYZ volume="LeadBandPipe2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe2" envelope="LBO2">
+    <posXYZ volume="LBI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD2" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO2" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI2" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 6 -->
+
+<!-- Without DET2
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  25.71"/>
+  </composition>
+-->
+
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.08" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.74" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.82"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  19.9" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  35.98"/>
+  </composition>
+
+  <composition name="FlangeSixDisk1" envelope="F6O1">
+    <posXYZ volume="F6I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+<!-- Without DET2
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+-->
+
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.16" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk2" envelope="F6O2">
+    <posXYZ volume="F6I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk3" envelope="F6O3">
+    <posXYZ volume="F6I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F6I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSixDisk4" envelope="F6O4">
+    <posXYZ volume="F6I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk5" envelope="F6O5">
+    <posXYZ volume="F6I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O5" Rio_Z="0.0  2.54   29.0" material="Iron" />
+  <tubs name="F6I5" Rio_Z="0.0  2.38   29.0" material="Vacuum" />
+
+
+  <composition name="TargetBox">
+    <posXYZ volume="TargetBoxDisk1" X_Y_Z="0.0 0.0 -10.9"/>
+    <posXYZ volume="TargetBoxDisk2" X_Y_Z="0.0 0.0  0.0" />
+    <posXYZ volume="TargetBoxDisk3" X_Y_Z="0.0 0.0  10.9"/>
+  </composition>
+
+  <composition name="TargetBoxDisk1" envelope="TBO1">
+    <posXYZ volume="TBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO1" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI1" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+  <composition name="TargetBoxDisk2" envelope="TBO2">
+    <posXYZ volume="TargetInnerBox" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="TargetInnerBox" envelope="TBI2">
+    <posXYZ volume="CONV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO2" X_Y_Z="22.0  20.0  21.6" material="Iron" />
+  <box name="TBI2" X_Y_Z="21.6  19.6  21.6" material="Vacuum" />
+
+  <composition name="TargetBoxDisk3" envelope="TBO3">
+    <posXYZ volume="TBI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO3" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+  <box  name="CONV" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />
+
+
+
+
+
+
+<!-- Flange 7 -->
+
+  <composition name="Flange7">
+    <posXYZ volume="FlangeSevenDisk1" X_Y_Z="0.0  0.0  8.8721" />
+    <posXYZ volume="FlangeSevenDisk2" X_Y_Z="0.0  0.0  19.3224" />
+    <posXYZ volume="FlangeSevenDisk3" X_Y_Z="0.0  0.0  24.4024" />
+    <posXYZ volume="FlangeSevenDisk4" X_Y_Z="0.0  0.0  29.4824" />
+    <posXYZ volume="FlangeSevenDisk5" X_Y_Z="0.0  0.0  35.1924" />
+  </composition>
+
+  <composition name="FlangeSevenDisk1" envelope="F7O1">
+    <posXYZ volume="F7I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O1" Rio_Z="0.0  2.54  17.7424" material="Iron" />
+  <tubs name="F7I1" Rio_Z="0.0  2.38  17.7424" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk2" envelope="F7O2">
+    <posXYZ volume="F7I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk3" envelope="F7O3">
+    <posXYZ volume="F7I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F7I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk4" envelope="F7O4">
+    <posXYZ volume="F7I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk5" envelope="F7O5">
+    <posXYZ volume="F7I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O5" Rio_Z="0.0  2.54   8.26" material="Iron" />
+  <tubs name="F7I5" Rio_Z="0.0  2.38   8.26" material="Vacuum" />
+
+
+<!-- Concrete Wall -->
+
+  <composition name="ConcreteWall2" envelope="BLC2">
+    <posXYZ volume="ENTR" X_Y_Z="-179.0  0.0 -30.46"/>
+    <posXYZ volume="Block2Hole" X_Y_Z="0.0 -33.0 0.0"/>
+  </composition>
+
+  <box name="ENTR" X_Y_Z="92.0 266.0 61.0" material="Air" />
+
+  <composition name="Block2Hole" envelope="OBHO">
+    <posXYZ volume="IBHO"  X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="BLC2" X_Y_Z="450.0 266.0 121.92" material="Concrete" />
+  <tubs name="OBHO" Rio_Z="0.0  2.54  121.92" material="Iron" />
+  <tubs name="IBHO" Rio_Z="0.0  2.38  121.92" material="Vacuum" />
+
+
+<!-- Lead Wall -->
+
+  <composition name="shieldingWall" envelope="WALL">
+    <posXYZ volume="WallHole" X_Y_Z="0.0  -35.0  0.0"/>
+  </composition>
+
+  <box name="WALL" X_Y_Z="450. 270. 5.08" material="Lead" />
+
+  <composition name="WallHole" envelope="OWHO">
+    <posXYZ volume="IWHO" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="OWHO" Rio_Z="0.0  2.54 5.08" material="Iron" />
+  <tubs name="IWHO" Rio_Z="0.0  2.38 5.08" material="Vacuum" />
+
+
+<!-- Beam Pipe2 -->
+
+  <composition name="BeamPipe2" envelope="BPO2">
+  <!-- MUST COMMENT OUt either one or the other of the two lines below -->
+    <!-- <posXYZ volume="BeamPipe2Inner" /> enables the photon beam harp -->
+    <posXYZ volume="BPI2" /> <!-- disables the photon beam harp -->
+  </composition>
+  
+  <composition name="BeamPipe2Inner" envelope="BPI2">
+    <posXYZ volume="photonBeamHarp" X_Y_Z="0.0 0.0 -27.38" />
+  </composition>
+  
+  <composition name="photonBeamHarp">
+    <posXYZ volume="PSCV" />
+    <posXYZ volume="PSCH" />
+  </composition>
+
+  <tubs name="BPO2" Rio_Z="0.0  2.54   118.767" material="Iron" />
+  <tubs name="BPI2" Rio_Z="0.0  2.38   118.767" material="Vacuum" />
+    
+  <composition name="PairSpecConverter" envelope="PSCM">
+    <posXYZ volume="PSCV"/>
+    <posXYZ volume="PSCH"/>
+  </composition>
+  
+  <tubs name="PSCM" Rio_Z="0.0 2.38 0.53" material="Vacuum"/>
+  <tubs name="PSCV" Rio_Z="0.0 1.143 0.01" material="Aluminum"/>
+  <tubs name="PSCH" Rio_Z="1.143 2.38 0.53" material="Iron"/>
+
+  <tubs name="DET1" Rio_Z="0.   50.  2." material="Air" />
+  <box name="DET2" X_Y_Z=" 450. 270. 0.1" material="Vacuum" />
+  <box name="DET3" X_Y_Z=" 450. 2. 918." material="Air" />
+
+  
+<!-- The composition 'beamPipe' extends the vacuum from the pair 
+     spectrometer to the position of the target.
+
+     Origin of beamPipe is center of the hall.
+-->
+
+  <composition name="beamPipe">
+<!--    <posXYZ volume="DET4"     X_Y_Z="  0.0     0.0 -1400.0"/> -->
+    <posXYZ volume="DET5"     X_Y_Z="  0.0     0.0  1400.0"/> 
+    <posXYZ volume="TAC1" X_Y_Z="150.0  -350.0  1225.0" />  
+    <posXYZ volume="DarkWindow" X_Y_Z="  150.0  -350.0  320.0" />
+    <posXYZ volume="PlatformPipe" X_Y_Z="150.0  -350.0  650."/>
+    <posXYZ volume="PlexWindow" X_Y_Z="150.0  -350.0  830."/>
+    <posXYZ volume="IntMonitor" X_Y_Z="150.0  -350.0  834."/>
+    <posXYZ volume="DET6"     X_Y_Z="  0.0   600.0     0.0"/>
+    <!--posXYZ volume="DET7"     X_Y_Z="  0.0     0.0  -705.0"/--> 
+    <posXYZ volume="HallBellows" X_Y_Z="150.0 -350.0 -1223.287"/>
+    <posXYZ volume="HallPipe" X_Y_Z="150.0  -350.0  -1026.77"/>
+    <!-- Plastic scintillator for beam diagonistics -->
+    <!--posXYZ volume="DET8" X_Y_Z="150 -350.0 -834.0 "/-->
+  </composition>
+
+  <composition name="DarkWindow">
+    <posXYZ volume="DBOW" X_Y_Z="  0.0  0.0  0.0" />
+    <posXYZ volume="DBEW" X_Y_Z="  0.0  0.0  0.0" />
+  </composition>
+
+  <tubs name="DBOW" Rio_Z="20.0  60.0  0.3"  material="Aluminum"/>
+  <tubs name="DBEW" Rio_Z="0.0   20.0  0.01" material="Tedlar"/>
+
+  <composition name="PlatformPipe">
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0  -176.5127" />
+    <posXYZ volume="PipeSection" X_Y_Z="0.0 0.0 0.0" />
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0   176.5127" />
+  </composition>
+
+  <tubs name="PPWD" Rio_Z="0.0   20.32  0.0254" material="Kapton" />
+
+  <composition name="PipeSection" envelope="PPOV">
+    <posXYZ volume="PPIV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PPOV" Rio_Z="0.0   20.32  353.0" material="Iron" />
+  <tubs name="PPIV" Rio_Z="0.0   20.04  353.0" material="Vacuum" />
+
+  <composition name="PlexWindow">
+    <posXYZ volume="PPPW" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="IntMonitor" >
+    <posXYZ volume="INTM" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box  name="INTM" X_Y_Z="2  6  1" material="Scintillator"  />
+
+  <tubs name="PPPW" Rio_Z="0.0   20.32  0.3" material="Plexiglas" />
+
+  <box  name="TAC1" X_Y_Z="20  20  45" material="leadGlassF800" sensitive="true" />
+
+
+  <box name="DET4" X_Y_Z="1700.0  1200.0  2.0" material="Vacuum" />
+  <box name="DET5" X_Y_Z="1700.0  1198.0  2.0" material="Air" />
+  <box name="DET6" X_Y_Z="1700.0  2.0  3000.0" material="Air" />
+  <!--box name="DET7" X_Y_Z="1700.0  1198.0  2.0" material="Air" /-->
+  <tubs name="DET7" Rio_Z="0.0 1.7399  2.0" material="Vacuum"
+        comment="disk detector inside beam pipe at target entrance" />
+  <box name="DET8" X_Y_Z="10.0 10.0 1.0" material="Scintillator" sensitive="true"/>
+
+<!-- Hall bellows -->
+<composition name="HallBellows" envelope="BLWO">
+  <posXYZ volume="BLWI" X_Y_Z="0.0 0.0 -3.5011"/>
+</composition>
+
+<pcon name="BLWO" material="Iron">
+  <polyplane Rio_Z="0.0 1.90500 -13.4"/>
+  <polyplane Rio_Z="0.0 1.90500 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 6.3978"/>
+</pcon>
+
+<tubs name="BLWI" Rio_Z="0. 1.7399 19.7978" material="Vacuum"/>
+
+<!-- Hall Pipe -->
+  <composition name="HallPipe" envelope="OHPI" >
+    <!--posXYZ volume="IHPI" X_Y_Z="0 0 98.6305"/-->
+    <posXYZ volume="InnerHallPipe" X_Y_Z="0.0 0.0 98.6305"/> 
+  </composition>
+
+  <composition name="InnerHallPipe" envelope="IHPI">
+    <posXYZ volume="DET7" X_Y_Z="0 0 280.0"/> 
+    <!--posXYZ volume="CAP1" X_Y_Z="0.0  0.0  190.11265" /-->
+  </composition>
+
+
+  <pcon name="OHPI" material="Iron">
+    <polyplane Rio_Z="0.0 4.27355 -190.1190"/>
+    <polyplane Rio_Z="0.0 4.27355 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +387.380"/>
+  </pcon>
+
+  <tubs name="IHPI" Rio_Z="0.0  1.7399 577.499" material="Vacuum" />
+  <tubs name="CAP1" Rio_Z="0.0  1.7399 0.0127" material="Kapton"/>
+
+<composition name="SixWayCross" envelope="SWCM">
+  <posXYZ volume="sixWayTube" X_Y_Z="0 0 0"/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0 0." rot="0. 180. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 90. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 270. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="90. 0. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="270. 0. 0."/>
+  <posXYZ volume="sixWayBox" X_Y_Z="0. 0. 0."/> 
+</composition>
+
+<box name="SWCM" X_Y_Z="67.9196 67.9196 67.9196" material="Air"
+     comment="Six-way cross mother volume"/>
+<pcon name="SWCP" material="StainlessSteel" comment="Vacuum pipe for 6-way cross">
+  <polyplane Rio_Z="0. 20.32 20.32"/>
+  <polyplane Rio_Z="0. 20.32 32.258"/>
+  <polyplane Rio_Z="0. 22.504 32.258"/>
+  <polyplane Rio_Z="0. 22.504 33.9598"/>
+</pcon>
+  
+<composition name="sixWayTube" envelope="SWCP">
+  <posXYZ volume="SWC2" X_Y_Z="0.0 0.0 27.1399"/>
+</composition>
+
+<composition name="sixWayBox" envelope="SWCB">
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 -20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 -20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="20.08125 0. 0." rot="0 90 0 "/>
+  <posXYZ volume="SWC1" X_Y_Z="-20.08125 0. 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeMotherVolume" X_Y_Z="0. 0. 0." />
+</composition>
+
+<composition name="coldCubeMotherVolume" envelope="CBXM">
+  <posXYZ volume="CBX1" X_Y_Z="0. -7.712  0."/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.1444"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.3032"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 -12.1444"/>
+  <posXYZ volume="CBXS" X_Y_Z="12.1444 4.28 0."/>
+  <posXYZ volume="CBXS" X_Y_Z="-12.1444 4.28 0."/>
+  <posXYZ volume="coldCubeTopPlate" X_Y_Z="0. 16.272 0." rot="90 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 -11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="11.9856 4.28 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="-11.9856 4.28 0." rot="0 90 0"/>
+</composition>
+
+<composition name="coldCubeBeamPlate" envelope="CBXB">
+  <posXYZ volume="CBH0" X_Y_Z="0. -4.2926 0."/>
+</composition>
+
+<composition name="coldCubeSidePlate" envelope="CBSP">
+  <posXYZ volume="CBH2" X_Y_Z="0. 0. 0."/>
+</composition>
+
+<composition name="coldCubeTopPlate" envelope="CHXT">
+  <posXYZ volume="CBH1" X_Y_Z="0. 0. 0." />
+</composition>
+
+<box name="CBSP" X_Y_Z="23.8124 23.8124 0.15875" material="Copper"/>
+<box name="CHXT" X_Y_Z="24.13 24.13 0.15875" material="Copper"/>
+<tubs name="CBH1" Rio_Z="0. 10.795 0.15875" material="Vacuum"/>
+<tubs name="CBH0" Rio_Z="0 1.27 0.15875" material="Vacuum" 
+      comment="Hole for beam"/>
+<box name="CBH2" X_Y_Z="19.05 19.05 0.15875" material="Vacuum"/>
+<box name="CBXB" X_Y_Z="21.8948 21.8948 0.15875" material="Copper"/>
+<box name="CBXS" X_Y_Z="0.15875 21.8948 21.8948" material="Copper"/>
+<box name="CBX1" X_Y_Z="24.13 0.15875 24.13" material="Copper"/>
+<box name="CBXM" X_Y_Z="39.685 39.685 39.685" material="Vacuum"/>
+<box name="SWCB" X_Y_Z="40.64 40.64 40.64" material="StainlessSteel"/>
+<tubs name="SWC1" Rio_Z="0 19.84248 0.4775" material="Vacuum"/>
+<tubs name="SWC2" Rio_Z="0. 19.84248 13.6398" material="Vacuum"/>
+
+<!-- Approximation for the beam profiler -->
+<box name="PFSC" X_Y_Z="12.8 12.8 0.2" material="Scintillator" sensitive="true"/>
+<box name="PFLD" X_Y_Z="10.0 10.0 0.1" material="Lead"/>
+
+<!-- Following is the definition of the active collimator.  It sits
+     on the upstream end of the primary collimator and acts as an
+     active absorber with segmented detection of the beam intensity.
+-->
+
+  <composition name="ColDetector" envelope="INSU">
+    <posXYZ volume="ColAssemblyFinal" X_Y_Z="0.0 0.0 0.50"/>
+    <posXYZ volume="HOUF" X_Y_Z="0.0  0.0  -1.85"/>
+  </composition>
+
+  <composition name="ColAssemblyFinal" envelope="HOUS">
+    <posXYZ volume="ColAssemblyInitial" X_Y_Z="0.0  0.0  -0.15"/>
+  </composition>
+  
+  <composition name="ColAssemblyInitial" envelope="AIRH">
+    <mposPhi volume="DIV1" ncopy="4" Phi0="0" dPhi="90" R_Z="3.375 0."/>  
+    <mposPhi volume="DIV2" ncopy="4" Phi0="45" dPhi="90"/>  
+    <mposPhi volume="innerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+    <mposPhi volume="outerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+  </composition>
+
+  <tubs name="INSU" Rio_Z="0.25   7.36  4.20" material="BoronNitride"/>
+ 
+  <tubs name="HOUS" Rio_Z="0.25   6.70  3.20" material="Aluminum" />
+ 
+  <tubs name="HOUF" Rio_Z="0.25   6.85  0.50" material="Aluminum"/>
+ 
+  <tubs name="AIRH" Rio_Z="0.25   6.5002  2.9" material="Air" />
+  <box  name="DIV1" X_Y_Z="6.25  0.1  2.9" material="Aluminum" />
+  <tubs name="DIV2" Rio_Z="2.7   2.8  2.9" profile="-42.870 85.740"
+                                           material="Aluminum" />
+
+  <composition name="innerPinCushionWedge" envelope="ACWI">
+    <posXYZ volume="ACBI" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="innerPinCushionRow_1" X_Y_Z="0.276 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_2" X_Y_Z="0.376 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_3" X_Y_Z="0.476 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_4" X_Y_Z="0.576 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_5" X_Y_Z="0.676 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_6" X_Y_Z="0.776 0.0 0.40" />
+  </composition>
+  <composition name="innerPinCushionRow_1" envelope="AIR1">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_2" envelope="AIR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_3" envelope="AIR3">
+    <mposY volume="PIN1" ncopy="5" Y0="-0.20" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_4" envelope="AIR4">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_5" envelope="AIR5">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_6" envelope="AIR6">
+    <mposY volume="PIN1" ncopy="9" Y0="-0.40" dY="0.10" />
+  </composition>
+
+  <composition name="outerPinCushionWedge" envelope="ACWO">
+    <posXYZ volume="ACBO" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 -1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 +1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 -1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 +1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 -1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 +1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 -1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 +1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_5" X_Y_Z="3.025 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_6" X_Y_Z="3.125 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_7" X_Y_Z="3.225 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_8" X_Y_Z="3.325 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_9" X_Y_Z="3.425 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_10" X_Y_Z="3.525 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_11" X_Y_Z="3.625 0.0 0.40" />
+  </composition>
+  <composition name="outerPinCushionRow_1" envelope="AOR1">
+    <posXYZ volume="PIN1" />
+  </composition>
+  <composition name="outerPinCushionRow_2" envelope="AOR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_3" envelope="AOR3">
+    <mposY volume="PIN1" ncopy="6" Y0="-0.25" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_4" envelope="AOR4">
+    <mposY volume="PIN1" ncopy="10" Y0="-0.45" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_5" envelope="AOR5">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_6" envelope="AOR6">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_7" envelope="AOR7">
+    <mposY volume="PIN1" ncopy="37" Y0="-1.80" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_8" envelope="AOR8">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_9" envelope="AOR9">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_10" envelope="AORA">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_11" envelope="AORB">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+
+  <tubs name="ACWI" Rio_Z="0.25 2.5  2.5" profile="-33. 66."
+         material="Air" comment="active collimator inner wedge" />  
+  <tubs name="ACWO" Rio_Z="2.97  6.0  2.5" profile="-33. 66."
+         material="Air" comment="active collimator outer wedge" />  
+  <tubs name="ACBI" Rio_Z="0.25 2.5  0.8" profile="-32. 64."
+         material="SoftTungsten" comment="inner wedge base plate" />  
+  <tubs name="ACBO" Rio_Z="3.0  6.0  0.8" profile="-30. 60."
+         material="SoftTungsten" comment="outer wedge base plate" />  
+
+  <box name="AIR1" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AIR2" X_Y_Z="0.051 0.40 1.7" material="Air" />
+  <box name="AIR3" X_Y_Z="0.051 0.50 1.7" material="Air" />
+  <box name="AIR4" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AIR5" X_Y_Z="0.051 0.80 1.7" material="Air" />
+  <box name="AIR6" X_Y_Z="0.051 0.90 1.7" material="Air" />
+
+  <box name="AOR1" X_Y_Z="0.051 0.10 1.7" material="Air" />
+  <box name="AOR2" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AOR3" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AOR4" X_Y_Z="0.051 1.00 1.7" material="Air" />
+  <box name="AOR5" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR6" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR7" X_Y_Z="0.051 3.70 1.7" material="Air" />
+  <box name="AOR8" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AOR9" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AORA" X_Y_Z="0.051 4.10 1.7" material="Air" />
+  <box name="AORB" X_Y_Z="0.051 4.10 1.7" material="Air" />
+
+  <box name="PIN1" X_Y_Z="0.051 0.051 1.7" material="SoftTungsten" />
+ 
+<!-- Following is the definition of the triplet polarimeter.  It sits
+     just before of the shielding wall at the downstream end of the
+     collimator cave, and contains a retractable pair conversion target
+     called PTAR. Forward pairs are detected in the pair spectrometer.
+-->
+
+<!-- Origin of TripletPolar is the beam axis midpoint
+     of the polarimeter vacuum box, as set by the outside walls. -->
+
+  <composition name="TripletPolar">
+     <apply region="nullBfield"/>
+     <posXYZ volume="tripletPolar" X_Y_Z="1.5 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tripletPolar">
+     <posXYZ volume="tpolEnclosure" />
+     <posXYZ volume="tpolVacuumBoxFlange" X_Y_Z="6.50 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTPT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTPM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTIT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTIM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFT" X_Y_Z="0.0 -7.91 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTFM" X_Y_Z="-4.0 4.0 +7.91" unit_length="in" />
+     <posXYZ volume="PTFF" X_Y_Z="-6.910 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 -8.5" unit_length="in" />
+     <posXYZ volume="PTKM" X_Y_Z="-4.0 4.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKF" X_Y_Z="-7.550 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTDR" X_Y_Z="7.25 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tpolVacuumBox" envelope="PTB0">
+     <posXYZ volume="tpolRailGuide" X_Y_Z="0.375 5.131 -3.380" unit_length="in" />
+     <posXYZ volume="tpolTargetCarrier" X_Y_Z="0.25 2.146 -3.380" rot="0 180 0" unit_length="in" />
+     <posXYZ volume="tpolTargetMotor" X_Y_Z="-1.625 4.1449 -1.6284" unit_length="in" />
+     <posXYZ volume="tpolRecoilDetectorCard" X_Y_Z="-1.625 0.0 -2.0" rot="0 0 22.5" unit_length="in" />
+     <posXYZ volume="PTA1" X_Y_Z="-1.625 0.0 -1.9796" unit_length="in" />
+     <posXYZ volume="PTA2" X_Y_Z="-1.625 0.0 -1.9795" unit_length="in" />
+     <posXYZ volume="PTA3" X_Y_Z="-1.625 0.0 -1.9794" unit_length="in" />
+     <posXYZ volume="PTA4" X_Y_Z="-1.625 0.0 -2.0204" unit_length="in" />
+     <!-- <posXYZ volume="PTA5" X_Y_Z="-1.625 0.0 -3.3651" unit_length="in" /> -->
+     <posXYZ volume="PTMP" X_Y_Z="0.0 5.8125 0.0" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 -5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 -4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="-5.125 5.745 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="-4.625 5.5525 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 -2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="0.4872 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="-3.7372 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="0.4872 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="-3.7372 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="0.4872 5.5 -0.6216" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="-3.7372 5.5 -0.6216" unit_length="in" />
+  </composition>
+
+  <composition name="tpolEnclosure" envelope="PTBO">
+     <posXYZ volume="tpolVacuumBox" X_Y_Z="0.125 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH3" X_Y_Z="-4.0 4.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH6" X_Y_Z="0.0 -6.125 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH5" X_Y_Z="-6.125 0.0 -2.0" rot="0 90 0" unit_length="in" />
+  </composition>
+
+  
+  <tubs name="PTAR" Rio_Z="0.0 0.375 0.0075" material="Beryllium" 
+	comment="polarimeter converter target" /> 
+  
+  
+  <box name="PTBO" X_Y_Z="12.5 12.5 12.5" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube1" />
+  <box name="PTB0" X_Y_Z="12.25 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube2" />
+  <box name="PTB1" X_Y_Z="0.5 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box flange subtraction" />
+  <box name="PTB2" X_Y_Z="0.5 15.0 17.0" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box door flange" />
+  <box name="PTB3" X_Y_Z="9.25 0.988 0.625" material="Aluminum" unit_length="in"
+                   comment="polarimeter rail guide" />
+  <box name="PTB4" X_Y_Z="9.25 0.312 0.125" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail gap subtraction" />
+  <box name="PTB5" X_Y_Z="9.25 0.365 0.375" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail box subtraction" />
+  <box name="PTB6" X_Y_Z="42.0 42.0 2.0" material="Iron" unit_length="mm"
+                   comment="polarimeter motor plate" />
+  <box name="PTB7" X_Y_Z="5.25 5.792 0.118" material="Aluminum" unit_length="in"
+                   comment="polarimeter target holder" />
+  <box name="PTB8" X_Y_Z="4.325 4.292 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter target holder subtraction" />
+  <tubs name="PTH0" Rio_Z="0.0 21.0 69.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motor" />
+  <tubs name="PTH1" Rio_Z="0.0 10.5 32.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motion gear" />
+  <tubs name="PTH2" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter beam hole subtraction" />
+  <tubs name="PTH3" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter motor hole subtraction" />
+  <tubs name="PTH4" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter auxilliary hole subtraction" />
+  <tubs name="PTH5" Rio_Z="0.0 1.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter feed hole subtraction" />
+  <tubs name="PTH6" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter turbo pump hole subtraction" />
+  <tubs name="PTH7" Rio_Z="0.0 0.375 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter converter tray subtraction" />
+
+  <composition name="tpolVacuumBoxFlange" envelope="PTB2">
+     <posXYZ volume="PTB1" />
+  </composition>
+  <composition name="tpolRailGuide" envelope="PTB3">
+     <posXYZ volume="PTB4" X_Y_Z="0.0 -0.338 0.0" unit_length="in" />
+     <posXYZ volume="PTB5" />
+  </composition>
+  <composition name="tpolTargetDisk" envelope="PTH7">
+     <posXYZ volume="PTAR" />
+  </composition>
+  <composition name="tpolTargetCarrier" envelope="PTB7">
+     <posXYZ volume="PTB8" X_Y_Z="0.4625 0.75 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="1.875 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="0.625 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="-0.625 -2.146 0.0" unit_length="in" />
+  </composition>
+  <composition name="tpolTargetMotor">
+     <posXYZ volume="PTH0" />
+     <posXYZ volume="PTB6" X_Y_Z="0.0 0.0 -35.5" unit_length="mm" />
+     <posXYZ volume="PTH1" X_Y_Z="0.0 0.0 -52.5" unit_length="mm" />
+  </composition>
+  
+  <composition name="tpolRecoilDetector" envelope="PTDE">
+     <posXYZ volume="tpolRecoilRing1" />
+     <posXYZ volume="tpolRecoilRing2" />
+     <posXYZ volume="tpolRecoilRing3" />
+     <posXYZ volume="tpolRecoilRing4" />
+     <posXYZ volume="tpolRecoilRing5" />
+     <posXYZ volume="tpolRecoilRing6" />
+     <posXYZ volume="tpolRecoilRing7" />
+     <posXYZ volume="tpolRecoilRing8" />
+     <posXYZ volume="tpolRecoilRing9" />
+     <posXYZ volume="tpolRecoilRing10" />
+     <posXYZ volume="tpolRecoilRing11" />
+     <posXYZ volume="tpolRecoilRing12" />
+     <posXYZ volume="tpolRecoilRing13" />
+     <posXYZ volume="tpolRecoilRing14" />
+     <posXYZ volume="tpolRecoilRing15" />
+     <posXYZ volume="tpolRecoilRing16" />
+     <posXYZ volume="tpolRecoilRing17" />
+     <posXYZ volume="tpolRecoilRing18" />
+     <posXYZ volume="tpolRecoilRing19" />
+     <posXYZ volume="tpolRecoilRing20" />
+     <posXYZ volume="tpolRecoilRing21" />
+     <posXYZ volume="tpolRecoilRing22" />
+     <posXYZ volume="tpolRecoilRing23" />
+     <posXYZ volume="tpolRecoilRing24" />
+  </composition>
+  <tubs name="PTDE" Rio_Z="11.0 35.0 1.5" material="Vacuum" unit_length="mm" 
+                   comment="container for the triplet polarimeter detector" />
+
+  <composition name="tpolRecoilRing1" envelope="PTRA">
+     <mposPhi volume="PTSA" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="1" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing2" envelope="PTRB">
+     <mposPhi volume="PTSB" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="2" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing3" envelope="PTRC">
+     <mposPhi volume="PTSC" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="3" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing4" envelope="PTRD">
+     <mposPhi volume="PTSD" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="4" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing5" envelope="PTRE">
+     <mposPhi volume="PTSE" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="5" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing6" envelope="PTRF">
+     <mposPhi volume="PTSF" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="6" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing7" envelope="PTRG">
+     <mposPhi volume="PTSG" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="7" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing8" envelope="PTRH">
+     <mposPhi volume="PTSH" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="8" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing9" envelope="PTRI">
+     <mposPhi volume="PTSI" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="9" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing10" envelope="PTRJ">
+     <mposPhi volume="PTSJ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="10" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing11" envelope="PTRK">
+     <mposPhi volume="PTSK" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="11" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing12" envelope="PTRL">
+     <mposPhi volume="PTSL" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="12" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing13" envelope="PTRM">
+     <mposPhi volume="PTSM" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="13" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing14" envelope="PTRN">
+     <mposPhi volume="PTSN" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="14" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing15" envelope="PTRO">
+     <mposPhi volume="PTSO" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="15" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing16" envelope="PTRP">
+     <mposPhi volume="PTSP" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="16" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing17" envelope="PTRQ">
+     <mposPhi volume="PTSQ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="17" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing18" envelope="PTRR">
+     <mposPhi volume="PTSR" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="18" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing19" envelope="PTRS">
+     <mposPhi volume="PTSS" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="19" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing20" envelope="PTRT">
+     <mposPhi volume="PTST" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="20" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing21" envelope="PTRU">
+     <mposPhi volume="PTSU" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="21" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing22" envelope="PTRV">
+     <mposPhi volume="PTSV" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="22" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing23" envelope="PTRW">
+     <mposPhi volume="PTSW" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="23" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing24" envelope="PTRX">
+     <mposPhi volume="PTSX" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="24" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+
+  <tubs name="PTRA" Rio_Z="11 12 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRB" Rio_Z="12 13 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRC" Rio_Z="13 14 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRD" Rio_Z="14 15 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRE" Rio_Z="15 16 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRF" Rio_Z="16 17 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRG" Rio_Z="17 18 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRH" Rio_Z="18 19 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRI" Rio_Z="19 20 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRJ" Rio_Z="20 21 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRK" Rio_Z="21 22 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRL" Rio_Z="22 23 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRM" Rio_Z="23 24 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRN" Rio_Z="24 25 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRO" Rio_Z="25 26 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRP" Rio_Z="26 27 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRQ" Rio_Z="27 28 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRR" Rio_Z="28 29 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRS" Rio_Z="29 30 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRT" Rio_Z="30 31 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRU" Rio_Z="31 32 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRV" Rio_Z="32 33 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRW" Rio_Z="33 34 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRX" Rio_Z="34 35 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTSA" Rio_Z="11 12 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSB" Rio_Z="12 13 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSC" Rio_Z="13 14 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSD" Rio_Z="14 15 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSE" Rio_Z="15 16 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSF" Rio_Z="16 17 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSG" Rio_Z="17 18 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSH" Rio_Z="18 19 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSI" Rio_Z="19 20 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSJ" Rio_Z="20 21 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSK" Rio_Z="21 22 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSL" Rio_Z="22 23 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSM" Rio_Z="23 24 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSN" Rio_Z="24 25 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSO" Rio_Z="25 26 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSP" Rio_Z="26 27 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSQ" Rio_Z="27 28 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSR" Rio_Z="28 29 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSS" Rio_Z="29 30 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTST" Rio_Z="30 31 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSU" Rio_Z="31 32 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSV" Rio_Z="32 33 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSW" Rio_Z="33 34 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSX" Rio_Z="34 35 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+
+  <tubs name="PTA1" Rio_Z="11 35 0.0006" material="Aluminum" unit_length="mm"
+                    comment="called blank1, whatever that is" />
+  <tubs name="PTA2" Rio_Z="11 35 0.0035" material="Silicon" unit_length="mm" 
+                    comment="called blank2, whatever that is" />
+  <tubs name="PTA3" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank3, whatever that is" />
+  <tubs name="PTA4" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank4, whatever that is" />
+  <tubs name="PTA5" Rio_Z="0.0 9.525 0.5" material="Vacuum" unit_length="mm"
+                    comment="called blank5, whatever that is" />
+
+  <composition name="tpolRecoilDetectorCard" envelope="PTCA">
+     <posXYZ volume="tpolRecoilDetector" />
+     <posXYZ volume="PTCH" />
+  </composition>
+
+  <pgon name="PTCA" segments="8" material="FR-4" unit_length="mm"
+                   comment="card that carries the recoil polarimeter detector">
+     <polyplane Rio_Z="0 60 -0.75" unit_length="mm" />
+     <polyplane Rio_Z="0 60 0.75" unit_length="mm" />
+  </pgon>
+  <tubs name="PTCH" Rio_Z="0.0 11.0 1.5" material="Vacuum" unit_length="mm"
+                   comment="central hole through the polarimeter card" />
+  
+  <tubs name="PTPB" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="beam pipe to the upstream/downstream" />
+  <tubs name="PTIB" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="beam vacuum to the upstream/downstream" />
+  <tubs name="PTPF" Rio_Z="1.9375 2.0 1.05" material="Iron" unit_length="in"
+                   comment="feed pipe to the side" />
+  <tubs name="PTIF" Rio_Z="0.0 1.9375 1.05" material="Vacuum" unit_length="in"
+                   comment="feed vacuum to the side" />
+  <tubs name="PTPT" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe" />
+  <tubs name="PTIT" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="turbo pump port vacuum" />
+  <tubs name="PTPM" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="motor port pipe" />
+  <tubs name="PTIM" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="motor port vacuum" />
+  <tubs name="PTPX" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="aux port pipe" />
+  <tubs name="PTIX" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="aux port vacuum" />
+  <tubs name="PTFB" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="beam pipe flange to the upstream/downstream" />
+  <tubs name="PTFX" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="aux port pipe flange" />
+  <tubs name="PTFT" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe flange" />
+  <tubs name="PTFM" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="motor port pipe flange" />
+  <tubs name="PTFF" Rio_Z="2.0 3.0 0.78" material="Iron" unit_length="in"
+                   comment="feed pipe flange" />
+  <tubs name="PTKX" Rio_Z="0.0 1.6875 0.5" material="Iron" unit_length="in"
+                   comment="aux port pipe cap" />
+  <tubs name="PTKM" Rio_Z="0.0 2.250 0.5" material="Iron" unit_length="in"
+                   comment="motor port pipe cap" />
+  <tubs name="PTKF" Rio_Z="0.0 3.0 0.5" material="Iron" unit_length="in"
+                   comment="feed pipe cap" />
+
+  <box name="PTMP" X_Y_Z="10.0 0.375 10.0" material="Aluminum" unit_length="in"
+                   comment="mounting plate" />
+  <box name="PTVR" X_Y_Z="6.0 0.51 0.25" material="Iron" unit_length="in"
+                   comment="vertical rack piece" />
+  <box name="PTHR" X_Y_Z="6.0 0.125 0.75" material="Iron" unit_length="in"
+                   comment="horizontal rack piece" />
+  <box name="PTBR" X_Y_Z="4.75 0.50 0.0625" material="Aluminum" unit_length="in"
+                   comment="horizontal bar piece" />
+  <box name="PTLG" X_Y_Z="0.5 7.987 0.125" material="Aluminum" unit_length="in"
+                   comment="support leg" />
+  <box name="PTVS" X_Y_Z="0.5 2.5 0.25" material="Aluminum" unit_length="in"
+                   comment="vertical support piece" />
+  <box name="PTHS" X_Y_Z="0.5 0.25 2.5" material="Aluminum" unit_length="in"
+                   comment="horizontal support piece" />
+  <box name="PTDR" X_Y_Z="1.0 15.0 17.0" material="Aluminum" unit_length="in"
+                   comment="vacuum box door" />
+
+  <!-- there is no mcfast model of the photon beamline -->
+
+</section>
+
+<!-- </HDDS> -->

--- a/BeamLine_HDDS_50_750.xml
+++ b/BeamLine_HDDS_50_750.xml
@@ -1,0 +1,1642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DOCTYPE HDDS>
+
+  Hall D Geometry Data Base: Beam Line
+  ************************************
+
+     version 1.0: Initial version	-rtj
+
+     Revision 1.1 10/18/2002 
+     -added concrete shielding to the collimator housing 
+     -added the virtual detectors to this code:
+        DET1: disk intercepting entire beam upstream of collimators
+        DET2: plane perpendicular to beam just after second collimator
+        DET3: plane mounted just below the ceiling of collimator cave
+        DET4: plane perpendicular to beam just after entry to hall
+        DET5: plane perpendicular to beam at photon dump end of hall
+        DET6: plane mounted just below the ceiling inside the hall
+        DET7: plane perpendicular to beam just before the target
+     -added a steel tube containing a vacuum that goes from the back of
+      the collimator to the front of the solenoid  
+     -csg-
+
+     Revision 1.2 10/28/2002
+     -revised collimator to the heavy shielding option 
+     -added a steel tube containing a vacuum in the WALL, SHLD and ABS2 volumes
+     -repositioned DET3 to be inside the collimator housing 
+     -removed the BEAM volume from the collimator system
+     -csg-
+
+     Revision 1.3 1/9/2003
+     -shrunk the size of the vacuum tube from r=5.3 to r=2.5 in order to
+      extend the tube into the second steering magnet
+     -csg-
+
+     Revision 1.4 06/16/2003
+     -mid-shielding option
+     -modified DET1, now a cylinder placed in front of primary collimator
+     -added tungsten pin-cushion detector model into simulation
+     -csg- 
+
+     Revision 2.0 05/16/2008
+     -moved DET2 to just after the second collimator, in agreement with
+      the comments below.  Somehow it got misplaced to upstream of the
+      second collimator.  I guess no one was using it until now.
+     -added the volume CONV for the pair conversion target located inside
+      the vacuum pipe just downstream of the second sweep magnet.  Right
+      now it its material is vacuum, but the thickness of 240 microns is
+      chosen to make a 0.1% converter if the material is set to Carbon.
+
+
+     Revision 2.1  12/12/2008, A.S., rtj
+       Made the following changes in the composition 'collimatorStack':
+  	  1. Added the composition BeamPipe0 describing a vacuum beam pipe at the entrance 
+             of the collimator cave:
+              - the beam pipe radius is 12.4 cm
+              - the exit window: 250 micron Kapton with the radius of 10.14 cm. 
+ 	  2. Moved the active collimator, DET1, and other components 83.96 cm upstream the 
+             beamline.
+          3. Changed layout of the 1st passive collimator to a composite W/Pb:
+	      - the inner part is a W  box,  5.08 x  5.08 x 20.0 cm3
+              - the outer part is a Pb box, 30.48 x 30.48 x 20.0 cm3 
+          4. Added  the vacuum beam pipe (Flange1 compositon) in front of the 1st sweeping 
+             magnet:
+              - use 150 micron Kapton entrance window
+              - vaccuum goes all the way downstream the beamline until the GlueX detector.
+          5. Modified the layout of the 1st sweeping magnet:
+              - the outer dimensions are 29.2 x 24.8 x 355.6 cm3
+              - the gap size is 10.22 x 4.9 cm2 
+              - the field inside the gap is 0.23 T (integrated field is 0.82 Tm)
+              - the elliptical vacuum pipe goes through the magnet. The semi-axes of the pipe 
+              are 4.95 cm and 2.29 cm.        
+          6. Added the concrete blocks around the 1st sweeping magnet, composition ConcreteWall1. 
+             The size of the wall is 101.6 x 147.32 x 121.92 cm3.
+          7. Added the composition Flange2 to connect the 1st sweeping magnet with a vacuum chamber.
+          8. Added a vacuum chamber after the 1st sweeping magnet with the following dimensions:
+              - 50.8 cm long tube with the inner and outer radii of Rin = 9.83 cm and Rout = 9.85.
+          9. Added the small lead wall after the vacuum chamber, composition LeadBand1.
+         10. Added the composition Flange3 to connect the vacuum pipe between the lead band and the
+             2nd collimatoor.
+         11. Changed material of the 2nd collimator from Nickel to Iron. The default pinhole 
+             diameter was changed from 1 cm to 0.6 cm.
+         12. Added the composition Flange4 to connect the vacuum pipe between the 2nd collimator and
+             the 2nd sweeping magnet.
+         13. Changed the layout of the second sweeping magnet:
+              - outer dimensions are 42 x 20.8 cm2
+              - the gap size is 20.3 x 5 cm2, the field in the gap is 0.23 T
+              - 1.75 cm radius vacuum beam pipe goes through the magnet.         
+         14. Added the composition Flange5 to connect 2nd the sweeping magnet with the vacuum beam 
+             pipe.           
+         15. Added a 1m long vacuum beam pipe. The inner and outer radii are 2.38 and 2.54 cm, 
+             respectively.
+         16. Added the small lead wall (composition LeadBand2), 81.28 x 20.32 x 10.16 cm3.
+         17. Placed the vertical plane DET2 after the lead wall. 
+         18. Added the composition Flange6 to connect the vacuum pipe between the lead wall and 
+             a pair spectrometer converter box.          
+         19. Added the pair spectrometer converter. The converter thickness and material can be set
+             in the box 'PTAR'   <box  name="PTAR" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />.
+         20. Added the composition Flange7 to connect the vacuum pipe between the converter and 
+             the concrete wall.
+         21. Modified the size of the concrete shielding wall to 450.0 x 270.0 x 121.92 cm3.
+             Added passage to the collimator cave.
+         22. Decreased thickness of the lead wall to 5.08 cm (size of the lead brick).
+              
+     Revision 2.2  12/22/2008
+       Modified the composition 'beamPipe'. Now 'beamPipe' extends the vacuum from the 
+       pair spectrometer to the position of the target.
+
+     Revision 3.0  3/2/2011
+       Large group of revisions, to reflect the beamline geometry and shielding
+       in the engineering drawings for the cave, and the new pair spectrometer.
+
+     Revision 3.1 9/6/2013
+       Updates for compatibility with geant4 -rtj
+       a) Many small shifts to various volumes to eliminate overlaps.
+       b) Changes to dimensions of the active collimator wedges, and even
+          the number of pins per row, so that all overlaps are eliminated.
+
+     Revision 3.2 12/12/2016
+       Updates to introduce the triplet polarimeter -rtj
+       a) renamed downstream PS converter target from PTAR to CONV
+       b) reserved the name PTAR for the triplet polarimeter target
+       c) incorporated a detailed geometric model of the triplet polarimeter
+          from the ASU group into the beamline geometry
+
+     Revision 3.3 3/27/2017
+     Added TAC and some material downstream the FCAL - A.S. 
+     - FCAL dark box window, FCAL platform pipe with plexiglass window, beam 
+     - intensity monitor, and TAC
+
+
+
+<HDDS specification="v1.0" xmlns="http://www.gluex.org/hdds">
+-->
+
+<section name        = "BeamLine"
+         version     = "3.2"
+         date        = "2016-12-12"
+         author      = "R.T. Jones"
+         top_volume  = "collimatorPackage"
+         specification = "v1.0">
+
+<!-- Origin of collimatorPackage is center of the entrance face of the
+     primary collimator.  					-->
+
+  <composition name="collimatorPackage">
+    <posXYZ volume="ShieldedCollimator" X_Y_Z="0.0  0.0  400.0" />
+  </composition>
+
+  <box name="SHLD" X_Y_Z="550.  550.  1300." material="Concrete"/>
+  <composition name="ShieldedCollimator" envelope="SHLD">
+    <posXYZ volume="pipeFromTaggerHall" X_Y_Z="0.0  0.0  -625.0" />
+    <posXYZ volume="collimatorCave" X_Y_Z="0.0  35.0  25.0" />
+  </composition>  
+ 
+  <box  name="CAVE" X_Y_Z="450. 270. 1250." material="Air" />
+  <composition name="collimatorCave" envelope="CAVE">
+    <posXYZ volume="collimatorStack" X_Y_Z="0.0 -35.0 -500.0"/>     
+<!--  <posXYZ volume="DET2" X_Y_Z="0.0  0.0  225.0" /> -->
+    <posXYZ volume="DET3" X_Y_Z="0.0  132.0  0.0" />
+  </composition>
+ 
+  <composition name="collimatorSubCave">
+    <posXYZ volume="collimatorStack" />
+  </composition>
+
+  <composition name="collimatorStack">
+    <posXYZ volume="BeamPipe0"     X_Y_Z="0.0  0.0  -125.0"  />
+    <!--posXYZ volume="PFLD"          X_Y_Z="0.0  0.0  -99.0"  />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -97.0"   />
+    <posXYZ volume="PFSC"          X_Y_Z="0.0  0.0  -93.0"   /-->
+    <posXYZ volume="DET1"          X_Y_Z="0.0  0.0  -49.46"  />
+    <posXYZ volume="ColDetector"   X_Y_Z="0.0  0.0  -46.16"  />
+    <posXYZ volume="PrimaryCol"    X_Y_Z="0.0  0.0  -33.96"  />
+    <posXYZ volume="Flange1"       X_Y_Z="0.0  0.0   11.52"  />
+    <posXYZ volume="sweepMagnet1"  X_Y_Z="0.0  0.0   189.32" />
+    <posXYZ volume="ConcreteWall1" X_Y_Z="0.0  0.0   107.96" />
+    <posXYZ volume="Flange2"       X_Y_Z="0.0  0.0   367.12" />
+    <posXYZ volume="VacuumChamber" X_Y_Z="0.0  0.0   426.54" />
+    <posXYZ volume="LeadBand1"     X_Y_Z="0.0  0.0   457.02" />
+    <posXYZ volume="Flange3"       X_Y_Z="0.0  0.0   462.10" />
+    <posXYZ volume="COL2"          X_Y_Z="0.0  0.0   555.04" />
+    <posXYZ volume="Flange4"       X_Y_Z="0.0  0.0   580.44" />
+    <posXYZ volume="sweepMagnet2"  X_Y_Z="0.0  0.0   630.28" />
+    <posXYZ volume="Flange5"       X_Y_Z="0.0  0.0   648.28" />
+    <posXYZ volume="BeamPipe1"     X_Y_Z="0.0  0.0   712.28" />
+    <posXYZ volume="LeadBand2"     X_Y_Z="0.0  0.0   743.52" />
+    <posXYZ volume="DET2"          X_Y_Z="0.0  35.0  748.65" /> 
+    <posXYZ volume="Flange6"       X_Y_Z="0.0  0.0   748.70" />
+    <posXYZ volume="TripletPolar"  X_Y_Z="0.0 0.0    820.00" />
+    <posXYZ volume="Flange7"       X_Y_Z="0.0  0.0   840.954" />
+    <posXYZ volume="ConcreteWall2" X_Y_Z="0.0  33.0  941.24" />
+    <posXYZ volume="shieldingWall" X_Y_Z="0.0  35.0 1004.74" />     
+    <!--    <posXYZ volume="TargetBox"     X_Y_Z="0.0  0.0 1085.00" />   -->
+    <posXYZ volume="BeamPipe2"     X_Y_Z="0.0  0.0  1066.668" /> 
+  </composition>
+  
+<!-- Beam Pipe 0 -->
+
+  <composition name="pipeFromTaggerHall" envelope="PFTH">
+    <posXYZ volume="PFTV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PFTH" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="PFTV" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipe0">
+    <posXYZ volume="BeamPipeTube"    X_Y_Z="0.0  0.0  25.0" />
+    <posXYZ volume="BeamPipeFlange1" X_Y_Z="0.0  0.0  48.58" />
+    <posXYZ volume="BeamPipeExitWindow" X_Y_Z="0.0  0.0  50.0" />
+    <posXYZ volume="BeamPipeFlange2" X_Y_Z="0.0  0.0  51.42"  />
+  </composition>
+
+  <composition name="BeamPipeTube" envelope="BPTO">
+    <posXYZ volume="BPTI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPTO" Rio_Z="0.0   12.7  50.0" material="Iron" />
+  <tubs name="BPTI" Rio_Z="0.0   12.4  50.0" material="Vacuum" />
+
+  <composition name="BeamPipeFlange1">
+    <posXYZ volume="BFO1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BFO1" Rio_Z="12.7   15.24  2.84" material="Iron" />
+
+  <composition name="BeamPipeExitWindow">
+    <posXYZ volume="FCAP" X_Y_Z="0.0  0.0  0.0125"/>
+  </composition>
+
+  <tubs name="FCAP" Rio_Z="0.0   10.16   0.025" material="Kapton" />
+
+  <composition name="BeamPipeFlange2">
+    <posXYZ volume="BFO2" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="BFO2" Rio_Z="10.16   15.24   2.84"  material="Iron" />
+
+
+<!-- Primary Collimator -->
+
+  <composition name="PrimaryCol" envelope="PCPB">
+    <posXYZ volume="TungstenInsert" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="PCPB"  X_Y_Z="30.48  30.48  20." material="Lead" />
+
+  <composition name="TungstenInsert" envelope="PCTT">
+    <posXYZ volume="PCTH" X_Y_Z="0.0 0.0 0.0" />
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.02865 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.05730 0 0" /-->
+    <!--posXYZ volume="PrimaryCollimatorAperture" rot="0.11459 0 0" /-->
+  </composition>
+  <composition name="PrimaryCollimatorAperture" envelope="PCTH">
+    <posXYZ volume="PCTI" X_Y_Z="0.0 0.0 -5.0" />
+  </composition>
+
+  <box  name="PCTT"  X_Y_Z="5.08   5.08   20." material="Tungsten" />
+  <!--tubs name="PCTH"  Rio_Z="0.0    0.17   20." material="Air" /-->
+  <tubs name="PCTH"  Rio_Z="0.0    0.25   20." material="Air" />
+  <tubs name="PCTI"  Rio_Z="0.05   0.25   10." material="Tungsten" 
+        comment="pin-hole insert for reduced intensity running" />
+
+
+<!-- Flange 1 -->
+
+  <composition name="Flange1">
+    <posXYZ volume="FlangeOneDisk" X_Y_Z="0.0  0.0  -7.72" />
+    <posXYZ volume="FlangeOneWindow" X_Y_Z="0.0  0.0  -6.65" />
+    <posXYZ volume="FlangeOnePipe" X_Y_Z="0.0  0.0  -3.325" />
+  </composition>
+
+  <composition name="FlangeOneDisk">
+    <posXYZ volume="FOI1" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="FOI1" Rio_Z="1.27  8.57  2.14"  material="Iron" />
+
+  <composition name="FlangeOneWindow">
+    <posXYZ volume="F1CP" X_Y_Z="0.0  0.0  -0.0075"/>
+  </composition>
+
+  <tubs name="F1CP" Rio_Z="0.0   1.27  0.015" material="Kapton" />
+
+  <composition name="FlangeOnePipe" envelope="FOPO">
+    <posXYZ volume="FOPI" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FOPO" Rxy_Z="5.11  2.45   6.65" material="Iron" />
+  <eltu name="FOPI" Rxy_Z="4.95  2.29   6.65" material="Vacuum" />
+
+
+<!-- 1st Sweeping Magnet -->
+
+  <composition name="sweepMagnet1" envelope="MAG1">
+    <posXYZ volume="POL1" X_Y_Z="0.0 +7.425 0.0" />
+    <posXYZ volume="POL1" X_Y_Z="0.0 -7.425 0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="-9.855 0.0  0.0" />
+    <posXYZ volume="GAP1" X_Y_Z="+9.855 0.0  0.0" />
+    <posXYZ volume="MagnetPipe1" X_Y_Z="0.0  0.0  0.0" />
+  </composition> 
+
+  <box name="MAG1" X_Y_Z="29.2 24.8 355.6" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <box name="POL1" X_Y_Z="29.2  9.95  355.6" material="Iron" />
+  <box name="GAP1" X_Y_Z="9.49  4.9   355.6" material="Iron" />
+
+  <composition name="MagnetPipe1" envelope="MPO1">
+    <posXYZ volume="MPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="MPO1" Rxy_Z="5.11  2.45  355.6" material="Iron" />
+  <eltu name="MPI1" Rxy_Z="4.95  2.29  355.6" material="Vacuum" />
+
+
+<!-- Concrete Wall around the 1st sweeping magnet -->
+
+  <composition name="ConcreteWall1">
+    <posXYZ volume="WTOP" X_Y_Z="0.0   +30.3  0.0" />
+    <posXYZ volume="WBOT" X_Y_Z="0.0   -56.2  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="+32.7   0.0  0.0" />
+    <posXYZ volume="WSID" X_Y_Z="-32.7   0.0  0.0" />
+  </composition> 
+
+  <box name="WTOP" X_Y_Z="101.6  35.8  121.92" material="Concrete" />
+  <box name="WBOT" X_Y_Z="101.6  87.6  121.92" material="Concrete" />
+  <box name="WSID" X_Y_Z="36.2   24.8  121.92" material="Concrete" />
+
+
+<!-- Flange 2 -->
+
+  <composition name="Flange2">
+    <posXYZ volume="FlangeTwoDisk1" X_Y_Z="0.0  0.0  2.29" />
+    <posXYZ volume="FlangeTwoDisk2" X_Y_Z="0.0  0.0  6.72"/>
+    <posXYZ volume="FlangeTwoDisk3" X_Y_Z="0.0  0.0  16.88"/>
+    <posXYZ volume="FlangeTwoDisk4" X_Y_Z="0.0  0.0  27.04"/>
+    <posXYZ volume="FlangeTwoDisk5" X_Y_Z="0.0  0.0  31.6"/>
+  </composition>
+
+  <composition name="FlangeTwoDisk1" envelope="FTO1">
+    <posXYZ volume="FTI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <eltu name="FTO1" Rxy_Z="5.11  2.45   4.58" material="Iron" />
+  <eltu name="FTI1" Rxy_Z="4.95  2.29   4.58" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk2" envelope="FTO2">
+    <posXYZ volume="FTI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO2" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI2" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk3" envelope="FTO3">
+    <posXYZ volume="FTI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO3" Rio_Z="0.0  6.21  16.04" material="Iron" />   
+  <tubs name="FTI3" Rio_Z="0.0  6.19  16.04" material="Vacuum" /> 
+
+  <composition name="FlangeTwoDisk4" envelope="FTO4">
+    <posXYZ volume="FTI4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO4" Rio_Z="0.0  8.57   4.28" material="Iron" />
+  <tubs name="FTI4" Rio_Z="0.0  6.19   4.28" material="Vacuum" />
+
+  <composition name="FlangeTwoDisk5" envelope="FTO5">
+    <posXYZ volume="FTI5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="FTO5" Rio_Z="0.0  6.35   4.84" material="Iron" />
+  <tubs name="FTI5" Rio_Z="0.0  6.19   4.84" material="Vacuum" />
+
+
+<!-- Vacuum chamber after the 1st sweeping magnet-->
+
+  <composition name="VacuumChamber">
+    <posXYZ volume="VacuumChambDisk1" X_Y_Z="0.0 0.0 -25.30"/>
+    <posXYZ volume="VacuumChambDisk2" X_Y_Z="0.0 0.0  0.0"/>
+    <posXYZ volume="VacuumChambDisk3" X_Y_Z="0.0 0.0  25.30"/>
+  </composition>
+
+  <composition name="VacuumChambDisk1" envelope="VCO1">
+    <posXYZ volume="VCI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO1" Rio_Z="0.0  9.85   0.2" material="Iron" />
+  <tubs name="VCI1" Rio_Z="0.0  6.19   0.2" material="Vacuum" />
+
+  <composition name="VacuumChambDisk2" envelope="VCO2">
+    <posXYZ volume="VCI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO2" Rio_Z="0.0  9.85  50.40" material="Iron" />
+  <tubs name="VCI2" Rio_Z="0.0  9.83  50.40" material="Vacuum" />
+
+  <composition name="VacuumChambDisk3" envelope="VCO3">
+    <posXYZ volume="VCI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="VCO3" Rio_Z="0.0  9.85  0.2" material="Iron" />
+  <tubs name="VCI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+
+<!-- Lead Band 1 -->
+
+  <composition name="LeadBand1" envelope="LBD1">
+    <posXYZ volume="LeadBandPipe1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe1" envelope="LBO1">
+    <posXYZ volume="LBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD1" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO1" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI1" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 3 -->
+
+  <composition name="Flange3">
+    <posXYZ volume="FlangeThreeDisk1" X_Y_Z="0.0  0.0  24.56" />
+    <posXYZ volume="FlangeThreeDisk2" X_Y_Z="0.0  0.0  50.70"/>
+    <posXYZ volume="FlangeThreeDisk3" X_Y_Z="0.0  0.0  55.78"/>
+    <posXYZ volume="FlangeThreeDisk4" X_Y_Z="0.0  0.0  60.86"/>
+    <posXYZ volume="FlangeThreeDisk5" X_Y_Z="0.0  0.0  64.99"/>
+  </composition>
+
+  <composition name="FlangeThreeDisk1" envelope="F3O1">
+    <posXYZ volume="F3I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O1" Rio_Z="0.0  2.54  49.12" material="Iron" />
+  <tubs name="F3I1" Rio_Z="0.0  2.38  49.12" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk2" envelope="F3O2">
+    <posXYZ volume="F3I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk3" envelope="F3O3">
+    <posXYZ volume="F3I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F3I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk4" envelope="F3O4">
+    <posXYZ volume="F3I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F3I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeThreeDisk5" envelope="F3O5">
+    <posXYZ volume="F3I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F3O5" Rio_Z="0.0  2.54   5.1" material="Iron" />
+  <tubs name="F3I5" Rio_Z="0.0  2.38   5.1" material="Vacuum" />
+
+
+<!-- 2nd Collimator -->
+
+  <composition name="COL2" envelope="OCOL">
+    <posXYZ volume="ICOL" X_Y_Z="0.0  0.0  0.0"/>
+  </composition>
+
+  <tubs name="OCOL" Rio_Z="0.0  10.0  50.8" material="Iron" />
+  <tubs name="ICOL" Rio_Z="0.0   0.5  50.8" material="Vacuum" />
+
+<!-- Flange 4 -->
+
+  <composition name="Flange4">
+    <posXYZ volume="FlangeFourDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFourDisk2" X_Y_Z="0.0  0.0  9.84"/>
+    <posXYZ volume="FlangeFourDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFourDisk4" X_Y_Z="0.0  0.0  20.0"/>
+    <posXYZ volume="FlangeFourDisk5" X_Y_Z="0.0  0.0  26.71"/>
+  </composition>
+
+  <composition name="FlangeFourDisk1" envelope="F4O1">
+    <posXYZ volume="F4I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F4I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+
+  <composition name="FlangeFourDisk2" envelope="F4O2">
+    <posXYZ volume="F4I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk3" envelope="F4O3">
+    <posXYZ volume="F4I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F4I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFourDisk4" envelope="F4O4">
+    <posXYZ volume="F4I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F4I4" Rio_Z="0.0  1.745  3.16" material="Vacuum" />
+
+  <composition name="FlangeFourDisk5" envelope="F4O5">
+    <posXYZ volume="F4I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F4O5" Rio_Z="0.0  1.905   10.26" material="Iron" />
+  <tubs name="F4I5" Rio_Z="0.0  1.745   10.26" material="Vacuum" />
+
+
+<!-- 2nd Sweeping Magnet -->
+
+  <composition name="sweepMagnet2">
+    <posXYZ volume="Core" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Core" envelope="POL2">
+    <posXYZ volume="Aperture" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <composition name="Aperture" envelope="GAP2">
+    <posXYZ volume="MagnetPipe2" X_Y_Z="0.0  0.0  0.0" />
+  </composition>
+
+  <box name="POL2" X_Y_Z="42.0  20.8  36.0" material="Iron" />
+  <box name="GAP2" X_Y_Z="20.3   5.0  36.0" material="Air" >
+    <apply region="sweepDipoleBfield" /> 
+  </box> 
+
+  <composition name="MagnetPipe2" envelope="MPO2">
+    <posXYZ volume="MPI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="MPO2" Rio_Z="0.0  1.905  36.0" material="Iron" />
+  <tubs name="MPI2" Rio_Z="0.0  1.745  36.0" material="Vacuum" />
+
+
+<!-- Flange 5 -->
+
+  <composition name="Flange5">
+    <posXYZ volume="FlangeFiveDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeFiveDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeFiveDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeFiveDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeFiveDisk5" X_Y_Z="0.0  0.0  29.71"/>
+  </composition>
+
+  <composition name="FlangeFiveDisk1" envelope="F5O1">
+    <posXYZ volume="F5I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O1" Rio_Z="0.0  1.905  8.26" material="Iron" />
+  <tubs name="F5I1" Rio_Z="0.0  1.745  8.26" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk2" envelope="F5O2">
+    <posXYZ volume="F5I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk3" envelope="F5O3">
+    <posXYZ volume="F5I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F5I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk4" envelope="F5O4">
+    <posXYZ volume="F5I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F5I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeFiveDisk5" envelope="F5O5">
+    <posXYZ volume="F5I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F5O5" Rio_Z="0.0  2.54  16.26" material="Iron" />
+  <tubs name="F5I5" Rio_Z="0.0  2.38  16.26" material="Vacuum" />
+
+
+<!-- Beam Pipe1 -->
+
+  <composition name="BeamPipe1" envelope="BPO1">
+    <posXYZ volume="BPI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="BPO1" Rio_Z="0.0  2.54  52.32" material="Iron" />
+  <tubs name="BPI1" Rio_Z="0.0  2.38  52.32" material="Vacuum" />
+
+<!-- Lead Band 2 -->
+
+  <composition name="LeadBand2" envelope="LBD2">
+    <posXYZ volume="LeadBandPipe2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="LeadBandPipe2" envelope="LBO2">
+    <posXYZ volume="LBI2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="LBD2" X_Y_Z="81.28 20.32 10.16" material="Lead" />
+  <tubs name="LBO2" Rio_Z="0.0  2.54  10.16" material="Iron" />
+  <tubs name="LBI2" Rio_Z="0.0  2.38  10.16" material="Vacuum" />
+
+
+<!-- Flange 6 -->
+
+<!-- Without DET2
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.13" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.84" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.92"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  20.0" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  25.71"/>
+  </composition>
+-->
+
+  <composition name="Flange6">
+    <posXYZ volume="FlangeSixDisk1" X_Y_Z="0.0  0.0  4.08" />
+    <posXYZ volume="FlangeSixDisk2" X_Y_Z="0.0  0.0  9.74" />
+    <posXYZ volume="FlangeSixDisk3" X_Y_Z="0.0  0.0  14.82"/>
+    <posXYZ volume="FlangeSixDisk4" X_Y_Z="0.0  0.0  19.9" />
+    <posXYZ volume="FlangeSixDisk5" X_Y_Z="0.0  0.0  35.98"/>
+  </composition>
+
+  <composition name="FlangeSixDisk1" envelope="F6O1">
+    <posXYZ volume="F6I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+<!-- Without DET2
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.26" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.26" material="Vacuum" />
+-->
+
+  <tubs name="F6O1" Rio_Z="0.0  2.54  8.16" material="Iron" />
+  <tubs name="F6I1" Rio_Z="0.0  2.38  8.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk2" envelope="F6O2">
+    <posXYZ volume="F6I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk3" envelope="F6O3">
+    <posXYZ volume="F6I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F6I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSixDisk4" envelope="F6O4">
+    <posXYZ volume="F6I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F6I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSixDisk5" envelope="F6O5">
+    <posXYZ volume="F6I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F6O5" Rio_Z="0.0  2.54   29.0" material="Iron" />
+  <tubs name="F6I5" Rio_Z="0.0  2.38   29.0" material="Vacuum" />
+
+
+  <composition name="TargetBox">
+    <posXYZ volume="TargetBoxDisk1" X_Y_Z="0.0 0.0 -10.9"/>
+    <posXYZ volume="TargetBoxDisk2" X_Y_Z="0.0 0.0  0.0" />
+    <posXYZ volume="TargetBoxDisk3" X_Y_Z="0.0 0.0  10.9"/>
+  </composition>
+
+  <composition name="TargetBoxDisk1" envelope="TBO1">
+    <posXYZ volume="TBI1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO1" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI1" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+
+  <composition name="TargetBoxDisk2" envelope="TBO2">
+    <posXYZ volume="TargetInnerBox" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="TargetInnerBox" envelope="TBI2">
+    <posXYZ volume="CONV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO2" X_Y_Z="22.0  20.0  21.6" material="Iron" />
+  <box name="TBI2" X_Y_Z="21.6  19.6  21.6" material="Vacuum" />
+
+  <composition name="TargetBoxDisk3" envelope="TBO3">
+    <posXYZ volume="TBI3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="TBO3" X_Y_Z="22.0  20.0  0.2" material="Iron" />
+  <tubs name="TBI3" Rio_Z="0.0  2.38  0.2" material="Vacuum" />
+  <box  name="CONV" X_Y_Z="1.0  1.0  0.0445" material="Aluminum" />
+
+
+
+
+
+
+<!-- Flange 7 -->
+
+  <composition name="Flange7">
+    <posXYZ volume="FlangeSevenDisk1" X_Y_Z="0.0  0.0  8.8721" />
+    <posXYZ volume="FlangeSevenDisk2" X_Y_Z="0.0  0.0  19.3224" />
+    <posXYZ volume="FlangeSevenDisk3" X_Y_Z="0.0  0.0  24.4024" />
+    <posXYZ volume="FlangeSevenDisk4" X_Y_Z="0.0  0.0  29.4824" />
+    <posXYZ volume="FlangeSevenDisk5" X_Y_Z="0.0  0.0  35.1924" />
+  </composition>
+
+  <composition name="FlangeSevenDisk1" envelope="F7O1">
+    <posXYZ volume="F7I1" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O1" Rio_Z="0.0  2.54  17.7424" material="Iron" />
+  <tubs name="F7I1" Rio_Z="0.0  2.38  17.7424" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk2" envelope="F7O2">
+    <posXYZ volume="F7I2" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O2" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I2" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk3" envelope="F7O3">
+    <posXYZ volume="F7I3" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O3" Rio_Z="0.0  2.08  7.0" material="Iron" />
+  <tubs name="F7I3" Rio_Z="0.0  2.06  7.0" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk4" envelope="F7O4">
+    <posXYZ volume="F7I4" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O4" Rio_Z="0.0  4.29   3.16" material="Iron" />
+  <tubs name="F7I4" Rio_Z="0.0  2.38   3.16" material="Vacuum" />
+
+  <composition name="FlangeSevenDisk5" envelope="F7O5">
+    <posXYZ volume="F7I5" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="F7O5" Rio_Z="0.0  2.54   8.26" material="Iron" />
+  <tubs name="F7I5" Rio_Z="0.0  2.38   8.26" material="Vacuum" />
+
+
+<!-- Concrete Wall -->
+
+  <composition name="ConcreteWall2" envelope="BLC2">
+    <posXYZ volume="ENTR" X_Y_Z="-179.0  0.0 -30.46"/>
+    <posXYZ volume="Block2Hole" X_Y_Z="0.0 -33.0 0.0"/>
+  </composition>
+
+  <box name="ENTR" X_Y_Z="92.0 266.0 61.0" material="Air" />
+
+  <composition name="Block2Hole" envelope="OBHO">
+    <posXYZ volume="IBHO"  X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box name="BLC2" X_Y_Z="450.0 266.0 121.92" material="Concrete" />
+  <tubs name="OBHO" Rio_Z="0.0  2.54  121.92" material="Iron" />
+  <tubs name="IBHO" Rio_Z="0.0  2.38  121.92" material="Vacuum" />
+
+
+<!-- Lead Wall -->
+
+  <composition name="shieldingWall" envelope="WALL">
+    <posXYZ volume="WallHole" X_Y_Z="0.0  -35.0  0.0"/>
+  </composition>
+
+  <box name="WALL" X_Y_Z="450. 270. 5.08" material="Lead" />
+
+  <composition name="WallHole" envelope="OWHO">
+    <posXYZ volume="IWHO" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="OWHO" Rio_Z="0.0  2.54 5.08" material="Iron" />
+  <tubs name="IWHO" Rio_Z="0.0  2.38 5.08" material="Vacuum" />
+
+
+<!-- Beam Pipe2 -->
+
+  <composition name="BeamPipe2" envelope="BPO2">
+  <!-- MUST COMMENT OUt either one or the other of the two lines below -->
+    <!-- <posXYZ volume="BeamPipe2Inner" /> enables the photon beam harp -->
+    <posXYZ volume="BPI2" /> <!-- disables the photon beam harp -->
+  </composition>
+  
+  <composition name="BeamPipe2Inner" envelope="BPI2">
+    <posXYZ volume="photonBeamHarp" X_Y_Z="0.0 0.0 -27.38" />
+  </composition>
+  
+  <composition name="photonBeamHarp">
+    <posXYZ volume="PSCV" />
+    <posXYZ volume="PSCH" />
+  </composition>
+
+  <tubs name="BPO2" Rio_Z="0.0  2.54   118.767" material="Iron" />
+  <tubs name="BPI2" Rio_Z="0.0  2.38   118.767" material="Vacuum" />
+    
+  <composition name="PairSpecConverter" envelope="PSCM">
+    <posXYZ volume="PSCV"/>
+    <posXYZ volume="PSCH"/>
+  </composition>
+  
+  <tubs name="PSCM" Rio_Z="0.0 2.38 0.53" material="Vacuum"/>
+  <tubs name="PSCV" Rio_Z="0.0 1.143 0.01" material="Aluminum"/>
+  <tubs name="PSCH" Rio_Z="1.143 2.38 0.53" material="Iron"/>
+
+  <tubs name="DET1" Rio_Z="0.   50.  2." material="Air" />
+  <box name="DET2" X_Y_Z=" 450. 270. 0.1" material="Vacuum" />
+  <box name="DET3" X_Y_Z=" 450. 2. 918." material="Air" />
+
+  
+<!-- The composition 'beamPipe' extends the vacuum from the pair 
+     spectrometer to the position of the target.
+
+     Origin of beamPipe is center of the hall.
+-->
+
+  <composition name="beamPipe">
+<!--    <posXYZ volume="DET4"     X_Y_Z="  0.0     0.0 -1400.0"/> -->
+    <posXYZ volume="DET5"     X_Y_Z="  0.0     0.0  1400.0"/> 
+    <posXYZ volume="TAC1" X_Y_Z="150.0  -350.0  1225.0" />  
+    <posXYZ volume="DarkWindow" X_Y_Z="  150.0  -350.0  320.0" />
+    <posXYZ volume="PlatformPipe" X_Y_Z="150.0  -350.0  650."/>
+    <posXYZ volume="PlexWindow" X_Y_Z="150.0  -350.0  830."/>
+    <posXYZ volume="IntMonitor" X_Y_Z="150.0  -350.0  834."/>
+    <posXYZ volume="DET6"     X_Y_Z="  0.0   600.0     0.0"/>
+    <!--posXYZ volume="DET7"     X_Y_Z="  0.0     0.0  -705.0"/--> 
+    <posXYZ volume="HallBellows" X_Y_Z="150.0 -350.0 -1223.287"/>
+    <posXYZ volume="HallPipe" X_Y_Z="150.0  -350.0  -1026.77"/>
+    <!-- Plastic scintillator for beam diagonistics -->
+    <!--posXYZ volume="DET8" X_Y_Z="150 -350.0 -834.0 "/-->
+  </composition>
+
+  <composition name="DarkWindow">
+    <posXYZ volume="DBOW" X_Y_Z="  0.0  0.0  0.0" />
+    <posXYZ volume="DBEW" X_Y_Z="  0.0  0.0  0.0" />
+  </composition>
+
+  <tubs name="DBOW" Rio_Z="20.0  60.0  0.3"  material="Aluminum"/>
+  <tubs name="DBEW" Rio_Z="0.0   20.0  0.01" material="Tedlar"/>
+
+  <composition name="PlatformPipe">
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0  -176.5127" />
+    <posXYZ volume="PipeSection" X_Y_Z="0.0 0.0 0.0" />
+    <posXYZ volume="PPWD" X_Y_Z="0.0  0.0   176.5127" />
+  </composition>
+
+  <tubs name="PPWD" Rio_Z="0.0   20.32  0.0254" material="Kapton" />
+
+  <composition name="PipeSection" envelope="PPOV">
+    <posXYZ volume="PPIV" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <tubs name="PPOV" Rio_Z="0.0   20.32  353.0" material="Iron" />
+  <tubs name="PPIV" Rio_Z="0.0   20.04  353.0" material="Vacuum" />
+
+  <composition name="PlexWindow">
+    <posXYZ volume="PPPW" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <composition name="IntMonitor" >
+    <posXYZ volume="INTM" X_Y_Z="0.0 0.0 0.0"/>
+  </composition>
+
+  <box  name="INTM" X_Y_Z="2  6  1" material="Scintillator"  />
+
+  <tubs name="PPPW" Rio_Z="0.0   20.32  0.3" material="Plexiglas" />
+
+  <box  name="TAC1" X_Y_Z="20  20  45" material="leadGlassF800" sensitive="true" />
+
+
+  <box name="DET4" X_Y_Z="1700.0  1200.0  2.0" material="Vacuum" />
+  <box name="DET5" X_Y_Z="1700.0  1198.0  2.0" material="Air" />
+  <box name="DET6" X_Y_Z="1700.0  2.0  3000.0" material="Air" />
+  <!--box name="DET7" X_Y_Z="1700.0  1198.0  2.0" material="Air" /-->
+  <tubs name="DET7" Rio_Z="0.0 1.7399  2.0" material="Vacuum"
+        comment="disk detector inside beam pipe at target entrance" />
+  <box name="DET8" X_Y_Z="10.0 10.0 1.0" material="Scintillator" sensitive="true"/>
+
+<!-- Hall bellows -->
+<composition name="HallBellows" envelope="BLWO">
+  <posXYZ volume="BLWI" X_Y_Z="0.0 0.0 -3.5011"/>
+</composition>
+
+<pcon name="BLWO" material="Iron">
+  <polyplane Rio_Z="0.0 1.90500 -13.4"/>
+  <polyplane Rio_Z="0.0 1.90500 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -7.9148"/>
+  <polyplane Rio_Z="0.0 4.27355 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -4.7652"/>
+  <polyplane Rio_Z="0.0 1.905 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 -2.8602"/>
+  <polyplane Rio_Z="0.0 2.0726 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 2.8602"/>
+  <polyplane Rio_Z="0.0 1.905 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 4.7652"/>
+  <polyplane Rio_Z="0.0 4.27355 6.3978"/>
+</pcon>
+
+<tubs name="BLWI" Rio_Z="0. 1.7399 19.7978" material="Vacuum"/>
+
+<!-- Hall Pipe -->
+  <composition name="HallPipe" envelope="OHPI" >
+    <!--posXYZ volume="IHPI" X_Y_Z="0 0 98.6305"/-->
+    <posXYZ volume="InnerHallPipe" X_Y_Z="0.0 0.0 98.6305"/> 
+  </composition>
+
+  <composition name="InnerHallPipe" envelope="IHPI">
+    <posXYZ volume="DET7" X_Y_Z="0 0 280.0"/> 
+    <!--posXYZ volume="CAP1" X_Y_Z="0.0  0.0  190.11265" /-->
+  </composition>
+
+
+  <pcon name="OHPI" material="Iron">
+    <polyplane Rio_Z="0.0 4.27355 -190.1190"/>
+    <polyplane Rio_Z="0.0 4.27355 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 -188.5442"/>
+    <polyplane Rio_Z="0.0 1.90500 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +385.678"/>
+    <polyplane Rio_Z="0.0 22.504 +387.380"/>
+  </pcon>
+
+  <tubs name="IHPI" Rio_Z="0.0  1.7399 577.499" material="Vacuum" />
+  <tubs name="CAP1" Rio_Z="0.0  1.7399 0.0127" material="Kapton"/>
+
+<composition name="SixWayCross" envelope="SWCM">
+  <posXYZ volume="sixWayTube" X_Y_Z="0 0 0"/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0 0." rot="0. 180. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 90. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="0. 270. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="90. 0. 0."/>
+  <posXYZ volume="sixWayTube" X_Y_Z="0. 0. 0." rot="270. 0. 0."/>
+  <posXYZ volume="sixWayBox" X_Y_Z="0. 0. 0."/> 
+</composition>
+
+<box name="SWCM" X_Y_Z="67.9196 67.9196 67.9196" material="Air"
+     comment="Six-way cross mother volume"/>
+<pcon name="SWCP" material="StainlessSteel" comment="Vacuum pipe for 6-way cross">
+  <polyplane Rio_Z="0. 20.32 20.32"/>
+  <polyplane Rio_Z="0. 20.32 32.258"/>
+  <polyplane Rio_Z="0. 22.504 32.258"/>
+  <polyplane Rio_Z="0. 22.504 33.9598"/>
+</pcon>
+  
+<composition name="sixWayTube" envelope="SWCP">
+  <posXYZ volume="SWC2" X_Y_Z="0.0 0.0 27.1399"/>
+</composition>
+
+<composition name="sixWayBox" envelope="SWCB">
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 0.0 -20.08125"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="0.0 -20.08125 0.0" rot="90 0 0"/>
+  <posXYZ volume="SWC1" X_Y_Z="20.08125 0. 0." rot="0 90 0 "/>
+  <posXYZ volume="SWC1" X_Y_Z="-20.08125 0. 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeMotherVolume" X_Y_Z="0. 0. 0." />
+</composition>
+
+<composition name="coldCubeMotherVolume" envelope="CBXM">
+  <posXYZ volume="CBX1" X_Y_Z="0. -7.712  0."/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.1444"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 12.3032"/>
+  <posXYZ volume="coldCubeBeamPlate" X_Y_Z="0. 4.28 -12.1444"/>
+  <posXYZ volume="CBXS" X_Y_Z="12.1444 4.28 0."/>
+  <posXYZ volume="CBXS" X_Y_Z="-12.1444 4.28 0."/>
+  <posXYZ volume="coldCubeTopPlate" X_Y_Z="0. 16.272 0." rot="90 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="0. 4.28 -11.9856"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="11.9856 4.28 0." rot="0 90 0"/>
+  <posXYZ volume="coldCubeSidePlate" X_Y_Z="-11.9856 4.28 0." rot="0 90 0"/>
+</composition>
+
+<composition name="coldCubeBeamPlate" envelope="CBXB">
+  <posXYZ volume="CBH0" X_Y_Z="0. -4.2926 0."/>
+</composition>
+
+<composition name="coldCubeSidePlate" envelope="CBSP">
+  <posXYZ volume="CBH2" X_Y_Z="0. 0. 0."/>
+</composition>
+
+<composition name="coldCubeTopPlate" envelope="CHXT">
+  <posXYZ volume="CBH1" X_Y_Z="0. 0. 0." />
+</composition>
+
+<box name="CBSP" X_Y_Z="23.8124 23.8124 0.15875" material="Copper"/>
+<box name="CHXT" X_Y_Z="24.13 24.13 0.15875" material="Copper"/>
+<tubs name="CBH1" Rio_Z="0. 10.795 0.15875" material="Vacuum"/>
+<tubs name="CBH0" Rio_Z="0 1.27 0.15875" material="Vacuum" 
+      comment="Hole for beam"/>
+<box name="CBH2" X_Y_Z="19.05 19.05 0.15875" material="Vacuum"/>
+<box name="CBXB" X_Y_Z="21.8948 21.8948 0.15875" material="Copper"/>
+<box name="CBXS" X_Y_Z="0.15875 21.8948 21.8948" material="Copper"/>
+<box name="CBX1" X_Y_Z="24.13 0.15875 24.13" material="Copper"/>
+<box name="CBXM" X_Y_Z="39.685 39.685 39.685" material="Vacuum"/>
+<box name="SWCB" X_Y_Z="40.64 40.64 40.64" material="StainlessSteel"/>
+<tubs name="SWC1" Rio_Z="0 19.84248 0.4775" material="Vacuum"/>
+<tubs name="SWC2" Rio_Z="0. 19.84248 13.6398" material="Vacuum"/>
+
+<!-- Approximation for the beam profiler -->
+<box name="PFSC" X_Y_Z="12.8 12.8 0.2" material="Scintillator" sensitive="true"/>
+<box name="PFLD" X_Y_Z="10.0 10.0 0.1" material="Lead"/>
+
+<!-- Following is the definition of the active collimator.  It sits
+     on the upstream end of the primary collimator and acts as an
+     active absorber with segmented detection of the beam intensity.
+-->
+
+  <composition name="ColDetector" envelope="INSU">
+    <posXYZ volume="ColAssemblyFinal" X_Y_Z="0.0 0.0 0.50"/>
+    <posXYZ volume="HOUF" X_Y_Z="0.0  0.0  -1.85"/>
+  </composition>
+
+  <composition name="ColAssemblyFinal" envelope="HOUS">
+    <posXYZ volume="ColAssemblyInitial" X_Y_Z="0.0  0.0  -0.15"/>
+  </composition>
+  
+  <composition name="ColAssemblyInitial" envelope="AIRH">
+    <mposPhi volume="DIV1" ncopy="4" Phi0="0" dPhi="90" R_Z="3.375 0."/>  
+    <mposPhi volume="DIV2" ncopy="4" Phi0="45" dPhi="90"/>  
+    <mposPhi volume="innerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+    <mposPhi volume="outerPinCushionWedge" ncopy="4" Phi0="45" dPhi="90" />
+  </composition>
+
+  <tubs name="INSU" Rio_Z="0.25   7.36  4.20" material="BoronNitride"/>
+ 
+  <tubs name="HOUS" Rio_Z="0.25   6.70  3.20" material="Aluminum" />
+ 
+  <tubs name="HOUF" Rio_Z="0.25   6.85  0.50" material="Aluminum"/>
+ 
+  <tubs name="AIRH" Rio_Z="0.25   6.5002  2.9" material="Air" />
+  <box  name="DIV1" X_Y_Z="6.25  0.1  2.9" material="Aluminum" />
+  <tubs name="DIV2" Rio_Z="2.7   2.8  2.9" profile="-42.870 85.740"
+                                           material="Aluminum" />
+
+  <composition name="innerPinCushionWedge" envelope="ACWI">
+    <posXYZ volume="ACBI" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="innerPinCushionRow_1" X_Y_Z="0.276 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_2" X_Y_Z="0.376 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_3" X_Y_Z="0.476 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_4" X_Y_Z="0.576 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_5" X_Y_Z="0.676 0.0 0.40" />
+    <posXYZ volume="innerPinCushionRow_6" X_Y_Z="0.776 0.0 0.40" />
+  </composition>
+  <composition name="innerPinCushionRow_1" envelope="AIR1">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_2" envelope="AIR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_3" envelope="AIR3">
+    <mposY volume="PIN1" ncopy="5" Y0="-0.20" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_4" envelope="AIR4">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_5" envelope="AIR5">
+    <mposY volume="PIN1" ncopy="7" Y0="-0.30" dY="0.10" />
+  </composition>
+  <composition name="innerPinCushionRow_6" envelope="AIR6">
+    <mposY volume="PIN1" ncopy="9" Y0="-0.40" dY="0.10" />
+  </composition>
+
+  <composition name="outerPinCushionWedge" envelope="ACWO">
+    <posXYZ volume="ACBO" X_Y_Z="0.0 0.0 -0.85" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 -1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_1" X_Y_Z="2.625 +1.50 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 -1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_2" X_Y_Z="2.725 +1.40 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 -1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_3" X_Y_Z="2.825 +1.35 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 -1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_4" X_Y_Z="2.925 +1.15 0.40" />
+    <posXYZ volume="outerPinCushionRow_5" X_Y_Z="3.025 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_6" X_Y_Z="3.125 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_7" X_Y_Z="3.225 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_8" X_Y_Z="3.325 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_9" X_Y_Z="3.425 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_10" X_Y_Z="3.525 0.0 0.40" />
+    <posXYZ volume="outerPinCushionRow_11" X_Y_Z="3.625 0.0 0.40" />
+  </composition>
+  <composition name="outerPinCushionRow_1" envelope="AOR1">
+    <posXYZ volume="PIN1" />
+  </composition>
+  <composition name="outerPinCushionRow_2" envelope="AOR2">
+    <mposY volume="PIN1" ncopy="3" Y0="-0.10" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_3" envelope="AOR3">
+    <mposY volume="PIN1" ncopy="6" Y0="-0.25" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_4" envelope="AOR4">
+    <mposY volume="PIN1" ncopy="10" Y0="-0.45" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_5" envelope="AOR5">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_6" envelope="AOR6">
+    <mposY volume="PIN1" ncopy="35" Y0="-1.70" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_7" envelope="AOR7">
+    <mposY volume="PIN1" ncopy="37" Y0="-1.80" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_8" envelope="AOR8">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_9" envelope="AOR9">
+    <mposY volume="PIN1" ncopy="39" Y0="-1.90" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_10" envelope="AORA">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+  <composition name="outerPinCushionRow_11" envelope="AORB">
+    <mposY volume="PIN1" ncopy="41" Y0="-2.00" dY="0.10" />
+  </composition>
+
+  <tubs name="ACWI" Rio_Z="0.25 2.5  2.5" profile="-33. 66."
+         material="Air" comment="active collimator inner wedge" />  
+  <tubs name="ACWO" Rio_Z="2.97  6.0  2.5" profile="-33. 66."
+         material="Air" comment="active collimator outer wedge" />  
+  <tubs name="ACBI" Rio_Z="0.25 2.5  0.8" profile="-32. 64."
+         material="SoftTungsten" comment="inner wedge base plate" />  
+  <tubs name="ACBO" Rio_Z="3.0  6.0  0.8" profile="-30. 60."
+         material="SoftTungsten" comment="outer wedge base plate" />  
+
+  <box name="AIR1" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AIR2" X_Y_Z="0.051 0.40 1.7" material="Air" />
+  <box name="AIR3" X_Y_Z="0.051 0.50 1.7" material="Air" />
+  <box name="AIR4" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AIR5" X_Y_Z="0.051 0.80 1.7" material="Air" />
+  <box name="AIR6" X_Y_Z="0.051 0.90 1.7" material="Air" />
+
+  <box name="AOR1" X_Y_Z="0.051 0.10 1.7" material="Air" />
+  <box name="AOR2" X_Y_Z="0.051 0.30 1.7" material="Air" />
+  <box name="AOR3" X_Y_Z="0.051 0.70 1.7" material="Air" />
+  <box name="AOR4" X_Y_Z="0.051 1.00 1.7" material="Air" />
+  <box name="AOR5" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR6" X_Y_Z="0.051 3.50 1.7" material="Air" />
+  <box name="AOR7" X_Y_Z="0.051 3.70 1.7" material="Air" />
+  <box name="AOR8" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AOR9" X_Y_Z="0.051 3.90 1.7" material="Air" />
+  <box name="AORA" X_Y_Z="0.051 4.10 1.7" material="Air" />
+  <box name="AORB" X_Y_Z="0.051 4.10 1.7" material="Air" />
+
+  <box name="PIN1" X_Y_Z="0.051 0.051 1.7" material="SoftTungsten" />
+ 
+<!-- Following is the definition of the triplet polarimeter.  It sits
+     just before of the shielding wall at the downstream end of the
+     collimator cave, and contains a retractable pair conversion target
+     called PTAR. Forward pairs are detected in the pair spectrometer.
+-->
+
+<!-- Origin of TripletPolar is the beam axis midpoint
+     of the polarimeter vacuum box, as set by the outside walls. -->
+
+  <composition name="TripletPolar">
+     <apply region="nullBfield"/>
+     <posXYZ volume="tripletPolar" X_Y_Z="1.5 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tripletPolar">
+     <posXYZ volume="tpolEnclosure" />
+     <posXYZ volume="tpolVacuumBoxFlange" X_Y_Z="6.50 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTPT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTPM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTPX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIB" X_Y_Z="-1.5 0.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIF" X_Y_Z="-6.775 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTIT" X_Y_Z="0.0 -7.25 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTIM" X_Y_Z="-4.0 4.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 -7.25" unit_length="in" />
+     <posXYZ volume="PTIX" X_Y_Z="2.0 3.0 +7.25" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFB" X_Y_Z="-1.5 0.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 -7.94" unit_length="in" />
+     <posXYZ volume="PTFX" X_Y_Z="2.0 3.0 +7.94" unit_length="in" />
+     <posXYZ volume="PTFT" X_Y_Z="0.0 -7.91 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTFM" X_Y_Z="-4.0 4.0 +7.91" unit_length="in" />
+     <posXYZ volume="PTFF" X_Y_Z="-6.910 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKX" X_Y_Z="2.0 3.0 -8.5" unit_length="in" />
+     <posXYZ volume="PTKM" X_Y_Z="-4.0 4.0 +8.5" unit_length="in" />
+     <posXYZ volume="PTKF" X_Y_Z="-7.550 0.0 -2.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTDR" X_Y_Z="7.25 0.0 0.0" unit_length="in" />
+  </composition>
+
+  <composition name="tpolVacuumBox" envelope="PTB0">
+     <posXYZ volume="tpolRailGuide" X_Y_Z="0.375 5.131 -3.380" unit_length="in" />
+     <posXYZ volume="tpolTargetCarrier" X_Y_Z="0.25 2.146 -3.380" rot="0 180 0" unit_length="in" />
+     <posXYZ volume="tpolTargetMotor" X_Y_Z="-1.625 4.1449 -1.6284" unit_length="in" />
+     <posXYZ volume="tpolRecoilDetectorCard" X_Y_Z="-1.625 0.0 -2.0" rot="0 0 22.5" unit_length="in" />
+     <posXYZ volume="PTA1" X_Y_Z="-1.625 0.0 -1.9796" unit_length="in" />
+     <posXYZ volume="PTA2" X_Y_Z="-1.625 0.0 -1.9795" unit_length="in" />
+     <posXYZ volume="PTA3" X_Y_Z="-1.625 0.0 -1.9794" unit_length="in" />
+     <posXYZ volume="PTA4" X_Y_Z="-1.625 0.0 -2.0204" unit_length="in" />
+     <!-- <posXYZ volume="PTA5" X_Y_Z="-1.625 0.0 -3.3651" unit_length="in" /> -->
+     <posXYZ volume="PTMP" X_Y_Z="0.0 5.8125 0.0" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 -5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 -4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="0.0 5.745 5.125" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="0.0 5.5525 4.625" unit_length="in" />
+     <posXYZ volume="PTVR" X_Y_Z="-5.125 5.745 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTHR" X_Y_Z="-4.625 5.5525 0.0" rot="0 90 0" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTBR" X_Y_Z="-1.625 -2.1122 -2.0903" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="0.4872 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTLG" X_Y_Z="-3.7372 1.6315 -2.1841" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="0.4872 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTVS" X_Y_Z="-3.7372 4.375 -1.9966" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="0.4872 5.5 -0.6216" unit_length="in" />
+     <posXYZ volume="PTHS" X_Y_Z="-3.7372 5.5 -0.6216" unit_length="in" />
+  </composition>
+
+  <composition name="tpolEnclosure" envelope="PTBO">
+     <posXYZ volume="tpolVacuumBox" X_Y_Z="0.125 0.0 0.0" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH2" X_Y_Z="-1.5 0.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH3" X_Y_Z="-4.0 4.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH6" X_Y_Z="0.0 -6.125 -2.0" rot="90 0 0" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 6.125" unit_length="in" />
+     <posXYZ volume="PTH4" X_Y_Z="2.0 3.0 -6.125" unit_length="in" />
+     <posXYZ volume="PTH5" X_Y_Z="-6.125 0.0 -2.0" rot="0 90 0" unit_length="in" />
+  </composition>
+
+  
+  <tubs name="PTAR" Rio_Z="0.0 0.375 0.0750" material="Beryllium" 
+	comment="polarimeter converter target" /> 
+  
+  
+  <box name="PTBO" X_Y_Z="12.5 12.5 12.5" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube1" />
+  <box name="PTB0" X_Y_Z="12.25 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box enclosure cube2" />
+  <box name="PTB1" X_Y_Z="0.5 12.0 12.0" material="Vacuum" unit_length="in"
+                   comment="polarimeter vacuum box flange subtraction" />
+  <box name="PTB2" X_Y_Z="0.5 15.0 17.0" material="Iron" unit_length="in"
+                   comment="polarimeter vacuum box door flange" />
+  <box name="PTB3" X_Y_Z="9.25 0.988 0.625" material="Aluminum" unit_length="in"
+                   comment="polarimeter rail guide" />
+  <box name="PTB4" X_Y_Z="9.25 0.312 0.125" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail gap subtraction" />
+  <box name="PTB5" X_Y_Z="9.25 0.365 0.375" material="Vacuum" unit_length="in"
+                   comment="polarimeter rail box subtraction" />
+  <box name="PTB6" X_Y_Z="42.0 42.0 2.0" material="Iron" unit_length="mm"
+                   comment="polarimeter motor plate" />
+  <box name="PTB7" X_Y_Z="5.25 5.792 0.118" material="Aluminum" unit_length="in"
+                   comment="polarimeter target holder" />
+  <box name="PTB8" X_Y_Z="4.325 4.292 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter target holder subtraction" />
+  <tubs name="PTH0" Rio_Z="0.0 21.0 69.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motor" />
+  <tubs name="PTH1" Rio_Z="0.0 10.5 32.0" material="Iron" unit_length="mm"
+                   comment="polarimeter target motion gear" />
+  <tubs name="PTH2" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter beam hole subtraction" />
+  <tubs name="PTH3" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter motor hole subtraction" />
+  <tubs name="PTH4" Rio_Z="0.0 0.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter auxilliary hole subtraction" />
+  <tubs name="PTH5" Rio_Z="0.0 1.9375 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter feed hole subtraction" />
+  <tubs name="PTH6" Rio_Z="0.0 1.3125 0.25" material="Vacuum" unit_length="in"
+                   comment="polarimeter turbo pump hole subtraction" />
+  <tubs name="PTH7" Rio_Z="0.0 0.375 0.118" material="Vacuum" unit_length="in"
+                   comment="polarimeter converter tray subtraction" />
+
+  <composition name="tpolVacuumBoxFlange" envelope="PTB2">
+     <posXYZ volume="PTB1" />
+  </composition>
+  <composition name="tpolRailGuide" envelope="PTB3">
+     <posXYZ volume="PTB4" X_Y_Z="0.0 -0.338 0.0" unit_length="in" />
+     <posXYZ volume="PTB5" />
+  </composition>
+  <composition name="tpolTargetDisk" envelope="PTH7">
+     <posXYZ volume="PTAR" />
+  </composition>
+  <composition name="tpolTargetCarrier" envelope="PTB7">
+     <posXYZ volume="PTB8" X_Y_Z="0.4625 0.75 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="1.875 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="0.625 -2.146 0.0" unit_length="in" />
+     <posXYZ volume="tpolTargetDisk" X_Y_Z="-0.625 -2.146 0.0" unit_length="in" />
+  </composition>
+  <composition name="tpolTargetMotor">
+     <posXYZ volume="PTH0" />
+     <posXYZ volume="PTB6" X_Y_Z="0.0 0.0 -35.5" unit_length="mm" />
+     <posXYZ volume="PTH1" X_Y_Z="0.0 0.0 -52.5" unit_length="mm" />
+  </composition>
+  
+  <composition name="tpolRecoilDetector" envelope="PTDE">
+     <posXYZ volume="tpolRecoilRing1" />
+     <posXYZ volume="tpolRecoilRing2" />
+     <posXYZ volume="tpolRecoilRing3" />
+     <posXYZ volume="tpolRecoilRing4" />
+     <posXYZ volume="tpolRecoilRing5" />
+     <posXYZ volume="tpolRecoilRing6" />
+     <posXYZ volume="tpolRecoilRing7" />
+     <posXYZ volume="tpolRecoilRing8" />
+     <posXYZ volume="tpolRecoilRing9" />
+     <posXYZ volume="tpolRecoilRing10" />
+     <posXYZ volume="tpolRecoilRing11" />
+     <posXYZ volume="tpolRecoilRing12" />
+     <posXYZ volume="tpolRecoilRing13" />
+     <posXYZ volume="tpolRecoilRing14" />
+     <posXYZ volume="tpolRecoilRing15" />
+     <posXYZ volume="tpolRecoilRing16" />
+     <posXYZ volume="tpolRecoilRing17" />
+     <posXYZ volume="tpolRecoilRing18" />
+     <posXYZ volume="tpolRecoilRing19" />
+     <posXYZ volume="tpolRecoilRing20" />
+     <posXYZ volume="tpolRecoilRing21" />
+     <posXYZ volume="tpolRecoilRing22" />
+     <posXYZ volume="tpolRecoilRing23" />
+     <posXYZ volume="tpolRecoilRing24" />
+  </composition>
+  <tubs name="PTDE" Rio_Z="11.0 35.0 1.5" material="Vacuum" unit_length="mm" 
+                   comment="container for the triplet polarimeter detector" />
+
+  <composition name="tpolRecoilRing1" envelope="PTRA">
+     <mposPhi volume="PTSA" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="1" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing2" envelope="PTRB">
+     <mposPhi volume="PTSB" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="2" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing3" envelope="PTRC">
+     <mposPhi volume="PTSC" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="3" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing4" envelope="PTRD">
+     <mposPhi volume="PTSD" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="4" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing5" envelope="PTRE">
+     <mposPhi volume="PTSE" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="5" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing6" envelope="PTRF">
+     <mposPhi volume="PTSF" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="6" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing7" envelope="PTRG">
+     <mposPhi volume="PTSG" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="7" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing8" envelope="PTRH">
+     <mposPhi volume="PTSH" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="8" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing9" envelope="PTRI">
+     <mposPhi volume="PTSI" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="9" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing10" envelope="PTRJ">
+     <mposPhi volume="PTSJ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="10" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing11" envelope="PTRK">
+     <mposPhi volume="PTSK" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="11" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing12" envelope="PTRL">
+     <mposPhi volume="PTSL" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="12" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing13" envelope="PTRM">
+     <mposPhi volume="PTSM" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="13" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing14" envelope="PTRN">
+     <mposPhi volume="PTSN" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="14" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing15" envelope="PTRO">
+     <mposPhi volume="PTSO" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="15" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing16" envelope="PTRP">
+     <mposPhi volume="PTSP" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="16" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing17" envelope="PTRQ">
+     <mposPhi volume="PTSQ" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="17" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing18" envelope="PTRR">
+     <mposPhi volume="PTSR" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="18" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing19" envelope="PTRS">
+     <mposPhi volume="PTSS" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="19" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing20" envelope="PTRT">
+     <mposPhi volume="PTST" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="20" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing21" envelope="PTRU">
+     <mposPhi volume="PTSU" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="21" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing22" envelope="PTRV">
+     <mposPhi volume="PTSV" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="22" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing23" envelope="PTRW">
+     <mposPhi volume="PTSW" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="23" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+  <composition name="tpolRecoilRing24" envelope="PTRX">
+     <mposPhi volume="PTSX" ncopy="32" Phi0="-16.875" dPhi="11.25">
+        <ring value="24" />
+        <sector value="1" step="1" />
+     </mposPhi>
+  </composition>
+
+  <tubs name="PTRA" Rio_Z="11 12 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRB" Rio_Z="12 13 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRC" Rio_Z="13 14 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRD" Rio_Z="14 15 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRE" Rio_Z="15 16 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRF" Rio_Z="16 17 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRG" Rio_Z="17 18 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRH" Rio_Z="18 19 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRI" Rio_Z="19 20 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRJ" Rio_Z="20 21 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRK" Rio_Z="21 22 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRL" Rio_Z="22 23 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRM" Rio_Z="23 24 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRN" Rio_Z="24 25 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRO" Rio_Z="25 26 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRP" Rio_Z="26 27 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRQ" Rio_Z="27 28 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRR" Rio_Z="28 29 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRS" Rio_Z="29 30 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRT" Rio_Z="30 31 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRU" Rio_Z="31 32 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRV" Rio_Z="32 33 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRW" Rio_Z="33 34 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTRX" Rio_Z="34 35 1.034" material="Silicon" unit_length="mm" />
+  <tubs name="PTSA" Rio_Z="11 12 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSB" Rio_Z="12 13 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSC" Rio_Z="13 14 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSD" Rio_Z="14 15 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSE" Rio_Z="15 16 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSF" Rio_Z="16 17 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSG" Rio_Z="17 18 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSH" Rio_Z="18 19 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSI" Rio_Z="19 20 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSJ" Rio_Z="20 21 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSK" Rio_Z="21 22 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSL" Rio_Z="22 23 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSM" Rio_Z="23 24 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSN" Rio_Z="24 25 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSO" Rio_Z="25 26 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSP" Rio_Z="26 27 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSQ" Rio_Z="27 28 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSR" Rio_Z="28 29 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSS" Rio_Z="29 30 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTST" Rio_Z="30 31 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSU" Rio_Z="31 32 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSV" Rio_Z="32 33 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSW" Rio_Z="33 34 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+  <tubs name="PTSX" Rio_Z="34 35 1.034" profile="-5.625 5.625" unit_length="mm"
+        material="Silicon" sensitive="true" />
+
+  <tubs name="PTA1" Rio_Z="11 35 0.0006" material="Aluminum" unit_length="mm"
+                    comment="called blank1, whatever that is" />
+  <tubs name="PTA2" Rio_Z="11 35 0.0035" material="Silicon" unit_length="mm" 
+                    comment="called blank2, whatever that is" />
+  <tubs name="PTA3" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank3, whatever that is" />
+  <tubs name="PTA4" Rio_Z="11 35 0.0015" material="Aluminum" unit_length="mm"
+                    comment="called blank4, whatever that is" />
+  <tubs name="PTA5" Rio_Z="0.0 9.525 0.5" material="Vacuum" unit_length="mm"
+                    comment="called blank5, whatever that is" />
+
+  <composition name="tpolRecoilDetectorCard" envelope="PTCA">
+     <posXYZ volume="tpolRecoilDetector" />
+     <posXYZ volume="PTCH" />
+  </composition>
+
+  <pgon name="PTCA" segments="8" material="FR-4" unit_length="mm"
+                   comment="card that carries the recoil polarimeter detector">
+     <polyplane Rio_Z="0 60 -0.75" unit_length="mm" />
+     <polyplane Rio_Z="0 60 0.75" unit_length="mm" />
+  </pgon>
+  <tubs name="PTCH" Rio_Z="0.0 11.0 1.5" material="Vacuum" unit_length="mm"
+                   comment="central hole through the polarimeter card" />
+  
+  <tubs name="PTPB" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="beam pipe to the upstream/downstream" />
+  <tubs name="PTIB" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="beam vacuum to the upstream/downstream" />
+  <tubs name="PTPF" Rio_Z="1.9375 2.0 1.05" material="Iron" unit_length="in"
+                   comment="feed pipe to the side" />
+  <tubs name="PTIF" Rio_Z="0.0 1.9375 1.05" material="Vacuum" unit_length="in"
+                   comment="feed vacuum to the side" />
+  <tubs name="PTPT" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe" />
+  <tubs name="PTIT" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="turbo pump port vacuum" />
+  <tubs name="PTPM" Rio_Z="1.3125 1.375 2.0" material="Iron" unit_length="in"
+                   comment="motor port pipe" />
+  <tubs name="PTIM" Rio_Z="0.0 1.3125 2.0" material="Vacuum" unit_length="in"
+                   comment="motor port vacuum" />
+  <tubs name="PTPX" Rio_Z="0.9375 1.0 2.0" material="Iron" unit_length="in"
+                   comment="aux port pipe" />
+  <tubs name="PTIX" Rio_Z="0.0 0.9375 2.0" material="Vacuum" unit_length="in"
+                   comment="aux port vacuum" />
+  <tubs name="PTFB" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="beam pipe flange to the upstream/downstream" />
+  <tubs name="PTFX" Rio_Z="1.0 1.6875 0.620" material="Iron" unit_length="in"
+                   comment="aux port pipe flange" />
+  <tubs name="PTFT" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="turbo pump port pipe flange" />
+  <tubs name="PTFM" Rio_Z="1.375 2.250 0.680" material="Iron" unit_length="in"
+                   comment="motor port pipe flange" />
+  <tubs name="PTFF" Rio_Z="2.0 3.0 0.78" material="Iron" unit_length="in"
+                   comment="feed pipe flange" />
+  <tubs name="PTKX" Rio_Z="0.0 1.6875 0.5" material="Iron" unit_length="in"
+                   comment="aux port pipe cap" />
+  <tubs name="PTKM" Rio_Z="0.0 2.250 0.5" material="Iron" unit_length="in"
+                   comment="motor port pipe cap" />
+  <tubs name="PTKF" Rio_Z="0.0 3.0 0.5" material="Iron" unit_length="in"
+                   comment="feed pipe cap" />
+
+  <box name="PTMP" X_Y_Z="10.0 0.375 10.0" material="Aluminum" unit_length="in"
+                   comment="mounting plate" />
+  <box name="PTVR" X_Y_Z="6.0 0.51 0.25" material="Iron" unit_length="in"
+                   comment="vertical rack piece" />
+  <box name="PTHR" X_Y_Z="6.0 0.125 0.75" material="Iron" unit_length="in"
+                   comment="horizontal rack piece" />
+  <box name="PTBR" X_Y_Z="4.75 0.50 0.0625" material="Aluminum" unit_length="in"
+                   comment="horizontal bar piece" />
+  <box name="PTLG" X_Y_Z="0.5 7.987 0.125" material="Aluminum" unit_length="in"
+                   comment="support leg" />
+  <box name="PTVS" X_Y_Z="0.5 2.5 0.25" material="Aluminum" unit_length="in"
+                   comment="vertical support piece" />
+  <box name="PTHS" X_Y_Z="0.5 0.25 2.5" material="Aluminum" unit_length="in"
+                   comment="horizontal support piece" />
+  <box name="PTDR" X_Y_Z="1.0 15.0 17.0" material="Aluminum" unit_length="in"
+                   comment="vacuum box door" />
+
+  <!-- there is no mcfast model of the photon beamline -->
+
+</section>
+
+<!-- </HDDS> -->

--- a/ccdb/hdds2ccdb.py
+++ b/ccdb/hdds2ccdb.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+#
+# hddm2ccdb.py - script fo reading and writing from the /GEOMETRY
+#                tables in ccdb.
+#
+# author: richard.t.jones at uconn.edu
+# version: may 17, 2018
+#
+# Usage: hddm2ccdb.py [-r <run>] [-v <var>] command
+#  where command is one of
+#    * ls <table>
+#    * get <table>
+#    * set <table> <comment>
+#  with
+#    <run> is a run number starting at 1 [1]
+#    <var> is a variation string [default]
+#    <table> is a GEOMETRY table name, eg BeamLine_HDDS.xml
+#    <comment> is a log comment to go with the ccdb update, in quotes
+#
+
+import os
+import sys
+import ccdb
+
+def usage():
+   print """
+   Usage: hddm2ccdb.py [-r <run>] [-v <var>] command
+     where command is one of
+       * ls <table>
+       * get <table>
+       * set <table> <comment>
+     with
+       <run> is a run number or range, like 10222 or 10222-10224 [1]
+       <var> is a variation string [default]
+       <table> is a GEOMETRY table name, eg BeamLine_HDDS.xml
+       <comment> is a log comment to go with the ccdb update, in quotes
+   """
+   sys.exit(1)
+
+def do_ls_table(tpath):
+   """
+   Print the metadata of the ccdb table identified in tpath 
+   """
+   table = provider.get_type_table(tpath)
+   try:
+      runs = run.split('-')
+      ass = provider.get_assignment(tpath, runs[0], var)
+   except:
+      print "no entry found"
+      return
+   print "run range:", "{0}-{1}".format(ass.run_range.min, ass.run_range.max)
+   print "variation:", ass.variation.name
+   print "modified:", ass.modified
+   print "comment:", ass.comment
+   print "author:", ass.author.name
+
+def do_get_table(tpath):
+   """
+   Print the contents of the ccdb table identified in tpath 
+   """
+   table = provider.get_type_table(tpath)
+   try:
+      runs = run.split('-')
+      ass = provider.get_assignment(tpath, runs[0], var)
+   except:
+      print "no entry found"
+      return
+   sys.stdout.write(ass.constant_set.vault)
+
+def do_set_table(tpath, comment):
+   """
+   Pull xml content from stdin, push into a new table row in ccdb
+   """
+   content = sys.stdin.read()
+   runs = run.split('-')
+   if len(runs) == 1:
+      runs.append(ccdb.INFINITE_RUN)
+   ass = provider.create_assignment([[content]], tpath, 
+                                    runs[0], runs[1],
+                                    var, comment)
+
+
+run = "1"
+var = "default"
+ls_table = ""
+get_table = ""
+set_table = ""
+comment = ""
+i = 1
+while i < len(sys.argv[1:]):
+   if sys.argv[i][:2] == "-r":
+      if len(sys.argv[i]) > 2:
+         run = sys.argv[i][2:]
+      else:
+         i += 1
+         run = sys.argv[i]
+   elif sys.argv[i][:2] == "-v":
+      if len(sys.argv[i]) > 2:
+         var = sys.argv[i][2:]
+      else:
+         i += 1
+         var = sys.argv[i]
+   elif sys.argv[i] == "ls":
+      i += 1
+      ls_table = sys.argv[i]
+   elif sys.argv[i] == "get":
+      i += 1
+      get_table = sys.argv[i]
+   elif sys.argv[i] == "set":
+      i += 1
+      set_table = sys.argv[i]
+      comment = " ".join(sys.argv[i+1:])
+   i += 1
+
+if not ls_table and not get_table and not set_table:
+   usage()
+
+# Connect to CCDB DB
+sqlite_connect_str = os.environ["JANA_CALIB_URL"]
+provider = ccdb.AlchemyProvider()
+provider.connect(sqlite_connect_str)
+provider.authentication.current_user_name = "jonesrt"
+
+# Get list of users by id so we can print names later
+users = {}
+ccdb_users = provider.get_users()
+for user in ccdb_users:
+   users[user.id] = user.name
+
+if ls_table:
+   do_ls_table("/GEOMETRY/" + ls_table)
+if get_table:
+   do_get_table("/GEOMETRY/" + get_table)
+if set_table:
+   do_set_table("/GEOMETRY/" + set_table, comment)

--- a/ccdb/rcdbscan.py
+++ b/ccdb/rcdbscan.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+#
+# rcdbscan.py - does a scan of the GlueX rcdb looking up run conditions
+#               related to the beamline, namely which primary collimator
+#               was in place and which TPOL converter.
+
+import os
+import sys
+import rcdb
+
+# Open database connection
+connect = os.environ["RCDB_CONNECTION"]
+db = rcdb.RCDBProvider(connect)
+
+conds = ["collimator_diameter", "polarimeter_converter"]
+values = db.select_values(val_names=conds)
+run = -1
+col = 0
+con = 0
+for value in values.rows:
+   lastcol = col
+   lastcon = con
+   run = value[0]
+   if value[1] == "5.0mm hole":
+      col = 50
+   elif value[1] == "3.4mm hole":
+      col = 34
+   elif value[1] == "Blocking":
+      col = 0
+   if value[2] == "Retracted":
+      con = 0
+   elif value[2] == "Be 75um":
+      con = 75
+   elif value[2] == "Be 750um":
+      con = 750
+   if col != lastcol or con != lastcon:
+      print run, col, con

--- a/ccdb/snap.sh
+++ b/ccdb/snap.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# snap.sh - grab a snapshort of the GlueX hdds geometry from ccdb
+#           for a given run number.
+#
+# author: richard.t.jones at uconn.edu
+# version: may 17, 2018
+
+function usage() {
+    echo "Usage: snap.sh <run_number> [ <variation> ]"
+    exit 1
+}
+
+if ! echo $1 | grep -q '^[0-9][0-9]*$'; then
+    usage
+elif [[ $# -gt 1 ]]; then
+    var=$2
+else
+    var=default
+fi
+run=$1
+
+mkdir -p $run.$var
+for sys in ForwardEMcal_HDDS.xml \
+           cpp_HDDS.xml \
+           ForwardTOF_HDDS.xml \
+           ForwardDC_HDDS.xml \
+           main_HDDS.xml \
+           UpstreamEMveto_HDDS.xml \
+           CentralDC_HDDS.xml \
+           StartCntr_HDDS.xml \
+           BarrelEMcal_HDDS.xml \
+           Target_HDDS.xml \
+           Material_HDDS.xml \
+           DIRC_HDDS.xml \
+           PairSpect_HDDS.xml \
+           Solenoid_HDDS.xml \
+           ForwardMWPC_HDDS.xml \
+           CerenkovCntr_HDDS.xml \
+           Regions_HDDS.xml \
+           BeamLine_HDDS.xml \
+           GapEMcal_HDDS.xml \
+           ComptonEMcal_HDDS.xml \
+           DIRC_HDDS_original.xml \
+           HDDS-1_1.xsd \
+           TargetCPP_HDDS.xml
+ do
+    ccdb -r $run -v "$var" dump /GEOMETRY/$sys \
+    | awk '/Working run is/{next}/^#Copied from/{next}/^ *<\?xml/{print substr($0,3);next}{print}' \
+    | head -n -1 >$run.$var/$sys
+ done


### PR DESCRIPTION
  whether the collimator is blocking (0), 3.4mm (34) or 5.0mm (50)
  and whether the TPOL converter is retracted (0), 75 micron Be (75)
  or 750 micron Be(750)
- introduce new tools for writing updated geometry files into the
  CCDB /GEOMETRY database tables, and for reading relevant beamline
  configuration values from the RCDB. [rtj]