### PR TITLE
Fix to DIRC and TOF overlap

### DIFF
--- a/DIRC_HDDS.xml
+++ b/DIRC_HDDS.xml
@@ -63,7 +63,7 @@
     </posXYZ>
 </composition>
 
-<box name="DCMV" X_Y_Z="700.0 250.0 100.0" material="OpticalAir" /> <!-- x was 560, y was  220, z was 80 -->
+<box name="DCMV" X_Y_Z="700.0 250.0 84.0" material="OpticalAir" /> <!-- x was 560, y was  220, z was 80 -->
 
 <!--
      DIRC bar box module (12 individual bars): 

--- a/main_HDDS.xml
+++ b/main_HDDS.xml
@@ -92,7 +92,7 @@
     <!--<posXYZ volume="CerenkovCntr" X_Y_Z="0.0 0.0 466.0" /> -->
     <!--posXYZ volume="GapEMcal" X_Y_Z="0.0 0.0 460.0" /-->
     <!-- To simulate DIRC hits uncomment the line below -->
-    <posXYZ volume="DIRC" X_Y_Z="0.0 0.0 590.000" />
+    <posXYZ volume="DIRC" X_Y_Z="0.0 0.0 595.600" />
     <posXYZ volume="ForwardTOF" X_Y_Z="0.308 0.225 605.793" rot="-0.0427 0.0461 -0.1813"/>
     <posXYZ volume="ForwardEMcal" X_Y_Z="0.529 -0.002 624.906" rot="-0.0418 -0.07019 -0.0149" />
     <!--posXYZ volume="ComptonEMcal" X_Y_Z="0.0 0.0 876.106" /-->


### PR DESCRIPTION
- reduced DIRC DCMV volume z-dimention to resolve overlap with TOF
- restored DIRC volume nominal z-position of 595.6 cm in main_HDDS