### PR TITLE
* disabled the assignment of nullBfield to the interior of the DIRC and

### DIFF
--- a/BarrelEMcal_HDDS.xml
+++ b/BarrelEMcal_HDDS.xml
@@ -319,7 +319,7 @@ caused conflict with drift chamber cable supports.
   <tubs name="BCAM" Rio_Z="64.2485 90.5185 425.0" profile="-3.75 7.5"
                     unit_length="cm" unit_angle="deg"
                     material="Air" comment="barrel calorimeter module">
-    <apply region="nullBfield"/>
+    <!--apply region="nullBfield"/-->
   </tubs>
   <tubs name="BCAS" Rio_Z="87.3435 90.5185 390.0" profile="-3.75 7.5"
                     unit_length="cm" unit_angle="deg"

--- a/DIRC_HDDS.xml
+++ b/DIRC_HDDS.xml
@@ -28,7 +28,7 @@
 <!-- DIRC assembly, 4 modules -->
 
 <composition name="DIRC">
-    <apply region="nullBfield"/>
+    <!--apply region="nullBfield"/-->
     <posXYZ volume="DRCC" X_Y_Z="0.0  0.0  -40.0" rot="0.0 0.0 0.0"/>
 </composition>
 


### PR DESCRIPTION
  BCAL volumes. This was done a long time ago to optimize tracking in
  geant3, but it seems to have negligible effect in geant4, plus it
  is an uncontrolled approximation, no longer needed. [rtj]