### PR TITLE
Fmwpc move v2

### DIFF
--- a/BeamLine_HDDS.xml
+++ b/BeamLine_HDDS.xml
@@ -841,7 +841,7 @@
 <!--    <posXYZ volume="DET4"     X_Y_Z="  0.0     0.0 -1400.0"/> -->
     <posXYZ volume="DET5"     X_Y_Z="  0.0     0.0  1400.0"/> 
     <posXYZ volume="TAC1" X_Y_Z="150.0  -350.0  1225.0" />  
-    <posXYZ volume="DarkWindow" X_Y_Z="  150.0  -350.0  320.0" />
+    <posXYZ volume="DarkWindow" X_Y_Z="  150.0  -350.0  290.0" />
     <posXYZ volume="PlatformPipe" X_Y_Z="150.0  -350.0  650."/>
     <posXYZ volume="PlexWindow" X_Y_Z="150.0  -350.0  830."/>
     <posXYZ volume="IntMonitor" X_Y_Z="150.0  -350.0  834."/>
@@ -858,7 +858,7 @@
     <posXYZ volume="DBEW" X_Y_Z="  0.0  0.0  0.0" />
   </composition>
 
-  <tubs name="DBOW" Rio_Z="20.0  60.0  0.3"  material="Aluminum"/>
+  <tubs name="DBOW" Rio_Z="20.0  80.0  0.3"  material="Aluminum"/>
   <tubs name="DBEW" Rio_Z="0.0   20.0  0.01" material="Tedlar"/>
 
   <composition name="PlatformPipe">

--- a/ForwardMWPC_HDDS.xml
+++ b/ForwardMWPC_HDDS.xml
@@ -31,7 +31,7 @@ in main_HDDS.xml
          version     = "2.0"
          date        = "2021-03-17"
          author      = "B. Zihlmann"
-         top_volume  = "MWPC"
+         top_volume  = "HALL"
          specification = "v1.0">
 
 <!-- Origin of ForwardMWPC is center of upstream face of the first MWPC -->
@@ -45,7 +45,32 @@ in main_HDDS.xml
   "FMWPC positions" in david.lawrence.nn@gmail.com account.
 -->
 
- <composition name="ForwardMWPC" envelope="MWPC">
+ <composition name="ForwardMWPC">
+   <posXYZ volume="CPA6"  X_Y_Z="0.0  0.0 -12.70" />
+   <posXYZ volume="CPA7"  X_Y_Z="0.0  0.0  -5.06" />
+   <posXYZ volume="CPN1"  X_Y_Z=" 5.47625 13.29 -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPN1"  X_Y_Z="-5.47625 13.29 -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPN1"  X_Y_Z=" 5.47625 -7.425 -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPN1"  X_Y_Z="-5.47625 -7.425 -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPN1"  X_Y_Z=" 5.47625 -11.64 -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPN1"  X_Y_Z="-5.47625 -11.64 -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPB1"  X_Y_Z=" 5.47625  9.5325  -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPB1"  X_Y_Z="-5.47625  9.5325  -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPB1"  X_Y_Z=" 5.47625 -9.5325  -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPB1"  X_Y_Z="-5.47625 -9.5325  -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPB2"  X_Y_Z=" 9.5235  4.0  -3.33" rot="0. 90.0 0.0"/>
+   <posXYZ volume="CPB2"  X_Y_Z=" 9.5235 -4.0  -3.33" rot="0. 90.0 0.0"/>
+   <posXYZ volume="CPB2"  X_Y_Z="-9.5235  4.0  -3.33" rot="0. 90.0 0.0"/>
+   <posXYZ volume="CPB2"  X_Y_Z="-9.5235 -4.0  -3.33" rot="0. 90.0 0.0"/>
+   <posXYZ volume="CPB3"  X_Y_Z=" 5.47625  14.115  -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPB3"  X_Y_Z="-5.47625  14.115  -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPB3"  X_Y_Z=" 5.47625 -14.115  -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPB3"  X_Y_Z="-5.47625 -14.115  -3.33" rot="90. 0.0 0.0"/>
+   <posXYZ volume="CPB4"  X_Y_Z=" 14.365  4.0  -3.33" rot="0. 90.0 0.0"/>
+   <posXYZ volume="CPB4"  X_Y_Z=" 14.365 -4.0  -3.33" rot="0. 90.0 0.0"/>
+   <posXYZ volume="CPB4"  X_Y_Z="-14.365  4.0  -3.33" rot="0. 90.0 0.0"/>
+   <posXYZ volume="CPB4"  X_Y_Z="-14.365 -4.0  -3.33" rot="0. 90.0 0.0"/>
+
 
     <posXYZ volume="CPPAbsorber1" X_Y_Z="0.0  0.0   2.50" />
     <posXYZ volume="CPPChamber"   X_Y_Z="0.0  0.0   7.63"> <layer value="1" /> </posXYZ>
@@ -58,12 +83,7 @@ in main_HDDS.xml
     <posXYZ volume="CPPAbsorber5" X_Y_Z="0.0  0.0 103.54" />
     <posXYZ volume="CPPChamber"   X_Y_Z="0.0  0.0 123.67"> <layer value="5" /> </posXYZ>
     <posXYZ volume="CPPChamber"   X_Y_Z="0.0  0.0 128.93"> <layer value="6" /> </posXYZ>
-    <!--
-    <posXYZ volume="CPPAbsorber6" X_Y_Z="0.0  0.0  79.65" />
-    <posXYZ volume="CPPAbsorber7" X_Y_Z="0.0  0.0 140.495" />
-    <posXYZ volume="CPPChamber"   X_Y_Z="0.0  0.0 189.53"> <layer value="7" /> </posXYZ>
-    <posXYZ volume="CPPChamber"   X_Y_Z="0.0  0.0 197.15"> <layer value="8" /> </posXYZ>
-    -->
+   
 
   </composition>
 
@@ -72,11 +92,6 @@ in main_HDDS.xml
  <composition name="CPPAbsorber3" envelope="CPA3"> <posXYZ volume="CPH3" X_Y_Z="0.0 0.0 0.0" /> </composition>
  <composition name="CPPAbsorber4" envelope="CPA4"> <posXYZ volume="CPH4" X_Y_Z="0.0 0.0 0.0" /> </composition>
  <composition name="CPPAbsorber5" envelope="CPA5"> <posXYZ volume="CPH5" X_Y_Z="0.0 0.0 0.0" /> </composition>
-
- <!--
- <composition name="CPPAbsorber6" envelope="CPA6"> <posXYZ volume="CPH6" X_Y_Z="0.0 0.0 0.0" /> </composition>
- <composition name="CPPAbsorber7" envelope="CPA7"> <posXYZ volume="CPH7" X_Y_Z="0.0 0.0 0.0" /> </composition>
- -->
 
  <composition name="CPPChamber" envelope="CPPF">
     <posXYZ volume="CPPWall" X_Y_Z="0.0 0.0 -1.815" />
@@ -94,7 +109,7 @@ in main_HDDS.xml
     <posXYZ volume="CPPH" X_Y_Z="0.0 0.0 0.0" />
  </composition>
 
-  <box name="MWPC" X_Y_Z="165.0 165.0 401.92"  material="Air" comment="forward MWPC mother" />
+  <!--box name="MWPC" X_Y_Z="165.0 165.0 401.92"  material="Air" comment="forward MWPC mother" /-->
   
   <!-- Absorbers are 61"x61" square with various thicknesses and a 8cm round beam hole -->
   <box name="CPA1" X_Y_Z="154.94 154.94  5.00" material="Lead" comment="Lead Absorber"/>
@@ -103,10 +118,17 @@ in main_HDDS.xml
   <box name="CPA4" X_Y_Z="154.94 154.94 35.00" material="Iron" comment="Iron Absorber"/>
   <box name="CPA5" X_Y_Z="154.94 154.94 35.00" material="Iron" comment="Iron Absorber"/>
 
-  <!--
-  <box name="CPA6" X_Y_Z="154.94 154.94 16.00" material="Iron" comment="Iron Absorber"/>
-  <box name="CPA7" X_Y_Z="154.94 154.94 90.45" material="Iron" comment="Iron Absorber"/>
-  -->
+  <pgon name="CPA6" segments="4" profile="-45 360" material="Lead" comment="Lead picture frame absorber">
+    <polyplane Rio_Z="4.0 7.0 0.0"/>
+    <polyplane Rio_Z="4.0 7.0 12.7"/>
+  </pgon>
+
+  <pgon name="CPA7" segments="4" profile="-45 360" material="Lead" comment="Angle profile for adjusting location of picture frame">
+    <polyplane Rio_Z="12.065 12.865 0.0"/>
+    <polyplane Rio_Z="12.065 12.865 4.26"/>
+    <polyplane Rio_Z="12.065 17.145 4.26"/>
+    <polyplane Rio_Z="12.065 17.145 5.06"/>
+  </pgon>
 
   <tubs name="CPH1" Rio_Z="0.0 4.0  5.00"  material="Air" comment="Lead Absorber beam hole" />
   <tubs name="CPH2" Rio_Z="0.0 4.0 10.00"  material="Air" comment="Iron Absorber beam hole" />
@@ -114,10 +136,12 @@ in main_HDDS.xml
   <tubs name="CPH4" Rio_Z="0.0 4.0 35.00"  material="Air" comment="Iron Absorber beam hole" />
   <tubs name="CPH5" Rio_Z="0.0 4.0 35.00"  material="Air" comment="Iron Absorber beam hole" />
 
-  <!--
-  <tubs name="CPH6" Rio_Z="0.0 4.0 16.00" material="Air" comment="Iron Absorber beam hole" />
-  <tubs name="CPH7" Rio_Z="0.0 4.0 90.45" material="Air" comment="Iron Absorber beam hole" />
-  -->
+  <tubs name="CPB1" Rio_Z="0.0 0.47625 5.065" material="StainlessSteel" comment="Verticle bolt"/>
+  <tubs name="CPB2" Rio_Z="0.0 0.3175 5.065" material="StainlessSteel" comment="Horizontal bolt"/>
+  <tubs name="CPB3" Rio_Z="0.0 0.47625 2.5" material="StainlessSteel" comment="Verticle bolt"/>
+  <tubs name="CPB4" Rio_Z="0.0 0.3175 3.0" material="StainlessSteel" comment="Horizontal bolt"/>
+  <tubs name="CPN1" Rio_Z="0.47625 1.05 0.85" material="StainlessSteel" comment="nut for picture frame adjustment"/>
+  
 
   <!-- MWPC frame is 64" x 64" x 5.26cm  -->
   <box name="CPPF" X_Y_Z="162.56 162.56 5.26"  material="FR-4" comment="G10 frame" />


### PR DESCRIPTION
Move CPP components out of MWPC mother volume into HALL.   Move the downstream exit wall for the FCAL dark box to a position in z just upstream of the CPP assembly.  Add the picture frame absorber assembly just upstream of the CPP lead plate.