### PR TITLE
Support C++20

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -6,8 +6,8 @@ from __future__ import unicode_literals
 from builtins import int
 from builtins import str
 from builtins import map
-from future import standard_library
-standard_library.install_aliases()
+# from future import standard_library
+# standard_library.install_aliases()
 import os
 import sys
 import subprocess
@@ -82,7 +82,7 @@ if SHOWBUILD==0:
 # Turn on debug symbols and warnings
 env.PrependUnique(      CFLAGS = ['-g', '-fPIC', '-Wall'])
 env.PrependUnique(    CXXFLAGS = ['-g', '-fPIC', '-Wall'])
-env.PrependUnique(    CXXFLAGS = ['-std=c++11'])
+env.PrependUnique(    CXXFLAGS = ['-std=c++20'])
 if gcc_version >= 10:
    env.PrependUnique(FORTRANFLAGS = ['-g', '-fPIC', '-fallow-argument-mismatch'])
 else:


### PR DESCRIPTION
This adds code to allow compilation with newer c++ standards up to and including c++20. This was only tested on the gluons running RHEL9.5 with gcc 11.5.0.

Note that this does include a change to the SConstruct file that specifies c++20 as the standard for compilation. (Previously it was c++11).